### PR TITLE
Fix banner inheritance for Bluetooth and health settings

### DIFF
--- a/S2Y/Bluetooth/BluetoothDevicesView.swift
+++ b/S2Y/Bluetooth/BluetoothDevicesView.swift
@@ -16,23 +16,19 @@ struct BluetoothDevicesView: View {
     @State private var selectedDevice: BluetoothHealthDevice?
     
     var body: some View {
-        NavigationView {
-            List {
-                scanningSection
-                connectedDevicesSectionIfNeeded
-                discoveredDevicesSectionIfNeeded
-                supportedDevicesSection
+        List {
+            scanningSection
+            connectedDevicesSectionIfNeeded
+            discoveredDevicesSectionIfNeeded
+            supportedDevicesSection
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                scanButton
             }
-            .navigationTitle("Bluetooth Devices")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    scanButton
-                }
-            }
-            .sheet(item: $selectedDevice) { device in
-                BluetoothDeviceDetailView(device: device)
-            }
+        }
+        .sheet(item: $selectedDevice) { device in
+            BluetoothDeviceDetailView(device: device)
         }
     }
     

--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -20,8 +20,7 @@ struct HealthAssistantSettingsView: View {
     @State private var errorMessage: String?
     
     var body: some View {
-        NavigationView {
-            Form {
+        Form {
                 Section {
                     Text("Configure LLM service to enable intelligent health analysis features")
                         .font(.caption)
@@ -110,30 +109,21 @@ struct HealthAssistantSettingsView: View {
                     }
                 }
             }
-            .navigationTitle("Health Assistant Settings")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Close") {
-                        dismiss()
-                    }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save Configuration") {
+                    saveConfiguration()
                 }
-                
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Save Configuration") {
-                        saveConfiguration()
-                    }
-                    .disabled(gatewayURL.isEmpty)
-                }
+                .disabled(gatewayURL.isEmpty)
             }
-            .alert("Success", isPresented: $showingSuccessAlert) {
-                Button("OK", role: .cancel) { }
-            } message: {
-                Text("Operation completed")
-            }
-            .onAppear {
-                loadConfiguration()
-            }
+        }
+        .alert("Success", isPresented: $showingSuccessAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Operation completed")
+        }
+        .onAppear {
+            loadConfiguration()
         }
     }
     

--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -11,7 +11,6 @@ import Security
 import SwiftUI
 
 struct HealthAssistantSettingsView: View {
-    @Environment(\.dismiss) private var dismiss
     @State private var gatewayURL: String = ""
     @State private var modelPath: String = ""
     @State private var bearerToken: String = ""

--- a/S2Y/Showcase/ShowcaseView.swift
+++ b/S2Y/Showcase/ShowcaseView.swift
@@ -96,7 +96,6 @@ struct ShowcaseView: View {
         Section("Bluetooth Health Devices") {
             NavigationLink("Manage Devices") {
                 BluetoothDevicesView()
-                    .navigationTitle("Bluetooth Devices")
             }
             
             Text("Connect health devices like blood pressure monitors, weight scales, and pulse oximeters.")


### PR DESCRIPTION
Remove explicit banner settings from Bluetooth Devices and Health Assistant Settings pages to inherit the parent navigation banner.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbc38159-a42d-4122-ad16-f646df5384e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbc38159-a42d-4122-ad16-f646df5384e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

