### PR TITLE
Restore healthgpt natural language communication

### DIFF
--- a/S2Y/HomeView.swift
+++ b/S2Y/HomeView.swift
@@ -19,7 +19,7 @@ struct HomeView: View {
     }
     
     
-    @AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.schedule
+    @AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.healthAssistant
     @AppStorage(StorageKeys.tabViewCustomization) private var tabViewCustomization = TabViewCustomization()
     
     @State private var presentingAccount = false
@@ -28,7 +28,7 @@ struct HomeView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Health Assistant", systemImage: "heart.text.square", value: .healthAssistant) {
-                EnhancedHealthAssistantView()
+                HealthAssistantView()
             }
                 .customizationID("home.healthAssistant")
             Tab("Schedule", systemImage: "list.clipboard", value: .schedule) {


### PR DESCRIPTION
Restore HealthGPT's natural language chat interface and set it as the default tab, abandoning the trend chart display.

---
<a href="https://cursor.com/background-agent?bcId=bc-75e14354-0d78-42b0-8619-e4017cb219e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75e14354-0d78-42b0-8619-e4017cb219e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

