### PR TITLE
Integrate the iOS health assistant with Omer

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -16,6 +16,8 @@ struct HealthAssistantSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var gatewayURL: String = ""
     @State private var modelPath: String = ""
+    @State private var transport: OmerTransport = .legacyAutoRAG
+    @State private var shareHealthData = false
     @State private var bearerToken: String = ""
     @State private var showingTokenField = false
     @State private var showingSuccessAlert = false
@@ -24,6 +26,10 @@ struct HealthAssistantSettingsView: View {
     @State private var hasStoredToken = false
     @AppStorage(StorageKeys.cloudflareGatewayURL) private var storedGatewayURL = ""
     @AppStorage(StorageKeys.cloudflareModelPath) private var storedModelPath = ""
+    @AppStorage(StorageKeys.omerMobileGatewayURL) private var storedMobileGatewayURL = ""
+    @AppStorage(StorageKeys.omerMobileModelPath) private var storedMobileModelPath = ""
+    @AppStorage(StorageKeys.omerTransport) private var storedTransport = ""
+    @AppStorage(StorageKeys.shareHealthDataWithOmer) private var storedShareHealthData = false
     @AppStorage(StorageKeys.disableTimeSensitiveNotifications) private var disableTSN = false
     @AppStorage(StorageKeys.disableScheduler) private var disableScheduler = false
     @AppStorage(StorageKeys.disableBluetooth) private var disableBluetooth = false
@@ -42,18 +48,23 @@ struct HealthAssistantSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Text("Adjust how the assistant connects, speaks, and stores data on this device.")
+                Text("Adjust how the assistant connects to Omer, speaks, and stores data on this device.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
 
             Section {
-                TextField("Gateway URL", text: $gatewayURL)
+                Picker("Connection", selection: $transport) {
+                    Text("Omer Mobile API").tag(OmerTransport.mobileV1)
+                    Text("Legacy AutoRAG").tag(OmerTransport.legacyAutoRAG)
+                }
+
+                TextField("Omer Gateway URL", text: $gatewayURL)
                     .textInputAutocapitalization(.never)
                     .keyboardType(.URL)
                     .autocorrectionDisabled()
 
-                TextField("Model Path", text: $modelPath, axis: .vertical)
+                TextField("Route / Model Path", text: $modelPath, axis: .vertical)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .lineLimit(2...4)
@@ -65,9 +76,9 @@ struct HealthAssistantSettingsView: View {
                 }
                 .disabled(usingBundledDefaults)
             } header: {
-                Text("Cloud Service")
+                Text("Omer Service")
             } footer: {
-                Text("Custom gateway values override the bundled defaults only on this device.")
+                Text("Custom Omer endpoint values override the bundled s2y-omer/Cloudflare defaults only on this device.")
             }
 
             Section {
@@ -101,45 +112,60 @@ struct HealthAssistantSettingsView: View {
                 Text("Use System Default to follow the device language for speech recognition and spoken responses.")
             }
 
-            Section {
-                LabeledContent("Bearer Token", value: hasStoredToken ? "Saved" : "Not Set")
+            if transport == .legacyAutoRAG {
+                Section {
+                    LabeledContent("Bearer Token", value: hasStoredToken ? "Saved" : "Not Set")
 
-                if showingTokenField {
-                    SecureField("Bearer Token", text: $bearerToken)
-                        .textContentType(.password)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
+                    if showingTokenField {
+                        SecureField("Bearer Token", text: $bearerToken)
+                            .textContentType(.password)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
 
-                    Button("Save Token") {
-                        saveTokenToKeychain()
-                    }
-                    .disabled(bearerToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        Button("Save Token") {
+                            saveTokenToKeychain()
+                        }
+                        .disabled(bearerToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
-                    Button("Cancel", role: .cancel) {
-                        cancelTokenEditing()
-                    }
-                } else {
-                    Button(hasStoredToken ? "Update Token" : "Set Token") {
-                        showingTokenField = true
-                    }
+                        Button("Cancel", role: .cancel) {
+                            cancelTokenEditing()
+                        }
+                    } else {
+                        Button(hasStoredToken ? "Update Token" : "Set Token") {
+                            showingTokenField = true
+                        }
 
-                    if hasStoredToken {
-                        Button("Remove Token", role: .destructive) {
-                            clearTokenFromKeychain()
+                        if hasStoredToken {
+                            Button("Remove Token", role: .destructive) {
+                                clearTokenFromKeychain()
+                            }
                         }
                     }
+                } header: {
+                    Text("Authentication")
+                } footer: {
+                    Text("Legacy AutoRAG tokens are stored in Keychain. Never distribute a provider token in the App bundle.")
                 }
-            } header: {
-                Text("Authentication")
-            } footer: {
-                Text("The access token is stored in Keychain and never shown in plain text after it is saved.")
+            } else {
+                Section {
+                    LabeledContent("Identity", value: "S2Y Account")
+                } header: {
+                    Text("Authentication")
+                } footer: {
+                    Text("Omer uses a short-lived Firebase identity token for the signed-in S2Y account.")
+                }
             }
 
-            Section("Data") {
+            Section {
+                Toggle("Share Relevant Health Summaries with Omer", isOn: $shareHealthData)
                 Button("Clear Health Data Cache", role: .destructive) {
                     HealthKitCache.shared.clearAll()
                     presentSuccess("Health data cache cleared")
                 }
+            } header: {
+                Text("Data")
+            } footer: {
+                Text("Health summaries stay on this device unless sharing is enabled. Omer receives only the currently relevant summary fields.")
             }
 
             #if DEBUG
@@ -187,6 +213,9 @@ struct HealthAssistantSettingsView: View {
         .onAppear {
             loadConfiguration()
         }
+        .onChange(of: transport) { _, newValue in
+            loadEndpointDraft(for: newValue)
+        }
     }
 
     private struct LanguageOption: Identifiable {
@@ -208,8 +237,9 @@ struct HealthAssistantSettingsView: View {
     }
     
     private func loadConfiguration() {
-        gatewayURL = resolvedGatewayURL
-        modelPath = resolvedModelPath
+        transport = resolvedTransport
+        loadEndpointDraft(for: transport)
+        shareHealthData = storedShareHealthData
         hasStoredToken = loadTokenFromKeychain() != nil
         bearerToken = ""
         showingTokenField = false
@@ -224,33 +254,62 @@ struct HealthAssistantSettingsView: View {
             return
         }
 
-        guard URL(string: normalizedGatewayURL) != nil else {
+        guard let serviceURL = URL(string: normalizedGatewayURL), serviceURL.host != nil else {
             errorMessage = "Enter a valid gateway URL."
             return
         }
 
-        storedGatewayURL = normalizedGatewayURL == bundledGatewayURL ? "" : normalizedGatewayURL
-        storedModelPath = normalizedModelPath == bundledModelPath ? "" : normalizedModelPath
-        gatewayURL = resolvedGatewayURL
-        modelPath = resolvedModelPath
+        guard transport != .mobileV1 || serviceURL.scheme?.lowercased() == "https" else {
+            errorMessage = "Omer Mobile API requires HTTPS."
+            return
+        }
+
+        if transport == .mobileV1 {
+            guard serviceURL.host?.lowercased() != "api.cloudflare.com" else {
+                errorMessage = "Enter the deployed s2y-omer service URL, not the Cloudflare API URL."
+                return
+            }
+            storedMobileGatewayURL = normalizedGatewayURL == bundledGatewayURL ? "" : normalizedGatewayURL
+            storedMobileModelPath = normalizedModelPath == bundledModelPath ? "" : normalizedModelPath
+        } else {
+            storedGatewayURL = normalizedGatewayURL == bundledGatewayURL ? "" : normalizedGatewayURL
+            storedModelPath = normalizedModelPath == bundledModelPath ? "" : normalizedModelPath
+        }
+        storedTransport = transport == bundledTransport ? "" : transport.rawValue
+        storedShareHealthData = shareHealthData
+        loadEndpointDraft(for: transport)
         errorMessage = nil
         presentSuccess("Health Assistant settings saved")
     }
     
     private func loadTokenFromKeychain() -> String? {
-        let keychain = Keychain()
-        return keychain.get(key: "gateway.token")
+        let serviceQuery = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "ai.cloudflare",
+            kSecAttrAccount as String: "gateway.token",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ] as [String: Any]
+        var item: CFTypeRef?
+        if SecItemCopyMatching(serviceQuery as CFDictionary, &item) == errSecSuccess,
+           let data = item as? Data {
+            return String(data: data, encoding: .utf8)
+        }
+        return Keychain().get(key: "gateway.token")
     }
     
     private func saveTokenToKeychain() {
         let query = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "ai.cloudflare",
             kSecAttrAccount as String: "gateway.token",
-            kSecValueData as String: bearerToken.data(using: .utf8) ?? Data(),
         ] as [String: Any]
 
         SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
+        var item = query
+        item[kSecValueData as String] = bearerToken.data(using: .utf8) ?? Data()
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(item as CFDictionary, nil)
 
         if status == errSecSuccess {
             hasStoredToken = true
@@ -292,8 +351,11 @@ struct HealthAssistantSettingsView: View {
     private func restoreDefaultServiceConfiguration() {
         storedGatewayURL = ""
         storedModelPath = ""
-        gatewayURL = bundledGatewayURL
-        modelPath = bundledModelPath
+        storedMobileGatewayURL = ""
+        storedMobileModelPath = ""
+        storedTransport = ""
+        transport = bundledTransport
+        loadEndpointDraft(for: transport)
         errorMessage = nil
     }
 
@@ -303,27 +365,49 @@ struct HealthAssistantSettingsView: View {
     }
 
     private var bundledGatewayURL: String {
-        (Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.GatewayURL") as? String)?
+        let key = transport == .mobileV1 ? "Omer.MobileGatewayURL" : "CFWorkersAI.GatewayURL"
+        return (Bundle.main.object(forInfoDictionaryKey: key) as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
     private var bundledModelPath: String {
-        (Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.ModelPath") as? String)?
+        let key = transport == .mobileV1 ? "Omer.MobileModelPath" : "CFWorkersAI.ModelPath"
+        return (Bundle.main.object(forInfoDictionaryKey: key) as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
     private var resolvedGatewayURL: String {
-        let override = storedGatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedValue = transport == .mobileV1 ? storedMobileGatewayURL : storedGatewayURL
+        let override = storedValue.trimmingCharacters(in: .whitespacesAndNewlines)
         return override.isEmpty ? bundledGatewayURL : override
     }
 
     private var resolvedModelPath: String {
-        let override = storedModelPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedValue = transport == .mobileV1 ? storedMobileModelPath : storedModelPath
+        let override = storedValue.trimmingCharacters(in: .whitespacesAndNewlines)
         return override.isEmpty ? bundledModelPath : override
     }
 
+    private var bundledTransport: OmerTransport {
+        let rawValue = Bundle.main.object(forInfoDictionaryKey: "Omer.Transport") as? String
+        return OmerTransport(rawValue: rawValue ?? "") ?? .legacyAutoRAG
+    }
+
+    private var resolvedTransport: OmerTransport {
+        OmerTransport(rawValue: storedTransport) ?? bundledTransport
+    }
+
+    private func loadEndpointDraft(for transport: OmerTransport) {
+        gatewayURL = resolvedGatewayURL
+        modelPath = resolvedModelPath
+        errorMessage = nil
+    }
+
     private var usingBundledDefaults: Bool {
-        storedGatewayURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && storedModelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let endpointUsesDefaults = transport == .mobileV1
+            ? storedMobileGatewayURL.isEmpty && storedMobileModelPath.isEmpty
+            : storedGatewayURL.isEmpty && storedModelPath.isEmpty
+        return endpointUsesDefaults
+            && storedTransport.isEmpty
     }
 }

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -60,6 +60,7 @@ struct HealthAssistantView: View {
     @State private var notice: AssistantNotice?
     @State private var showingSettings = false
     @State private var showingModelDownload = false
+    @State private var sendTask: Task<Void, Never>?
     @AppStorage("PreferLocalModel") private var preferLocalModel = false
     
     private let healthService = HealthKitService.shared
@@ -110,6 +111,10 @@ struct HealthAssistantView: View {
         }
         .task {
             await initializeHealthKit()
+        }
+        .onDisappear {
+            sendTask?.cancel()
+            sendTask = nil
         }
     }
     
@@ -163,7 +168,7 @@ struct HealthAssistantView: View {
                         HStack {
                             ProgressView()
                                 .scaleEffect(0.8)
-                            Text("Analyzing your health data...")
+                            Text(preferLocalModel ? "Generating locally..." : "Contacting Omer...")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
@@ -204,7 +209,8 @@ struct HealthAssistantView: View {
                     .disabled(isProcessing)
                 
                 Button {
-                    Task { await sendMessage() }
+                    sendTask?.cancel()
+                    sendTask = Task { await sendMessage() }
                 } label: {
                     Image(systemName: "paperplane.fill")
                         .foregroundColor(.white)
@@ -281,11 +287,24 @@ struct HealthAssistantView: View {
         inputText = ""
         isProcessing = true
         notice = nil
+        defer {
+            isProcessing = false
+            sendTask = nil
+        }
         
         do {
             let response = try await processHealthQuery(query)
+            try Task.checkCancellation()
             let assistantMessage = ChatMessage(role: .assistant, content: response)
             messages.append(assistantMessage)
+            if !preferLocalModel, enhancedProvider.lastError != nil {
+                notice = AssistantNotice(
+                    message: "Omer was unavailable, so this response was generated locally.",
+                    tone: .warning
+                )
+            }
+        } catch is CancellationError {
+            return
         } catch {
             let errorResponse = ChatMessage(
                 role: .assistant,
@@ -293,8 +312,6 @@ struct HealthAssistantView: View {
             )
             messages.append(errorResponse)
         }
-        
-        isProcessing = false
     }
     
     private func processHealthQuery(_ query: String) async throws -> String {
@@ -346,7 +363,7 @@ struct HealthAssistantView: View {
 
             HStack(spacing: 10) {
                 modeChip(
-                    title: preferLocalModel ? "Local AI" : "Cloud AI",
+                    title: preferLocalModel ? "Local AI" : "Omer",
                     systemImage: preferLocalModel ? "brain.head.profile" : "icloud",
                     tint: preferLocalModel ? .green : .blue
                 ) {

--- a/S2Y/LLM/ConversationContextManager.swift
+++ b/S2Y/LLM/ConversationContextManager.swift
@@ -33,7 +33,7 @@ public final class ConversationContextManager: ObservableObject {
         // Update context metadata
         updateContextMetadata(for: message)
         
-        logger.debug("Added message to context: \(message.role.rawValue) - \(message.content.prefix(50))...")
+        logger.debug("Added \(message.role.rawValue, privacy: .public) message to local conversation context")
     }
     
     /// Get conversation context for LLM
@@ -58,7 +58,7 @@ public final class ConversationContextManager: ObservableObject {
     public func updateHealthContext(metric: HealthKitService.MetricKind, value: String) {
         currentContext.healthContext[metric.rawValue] = value
         currentContext.lastHealthUpdate = Date()
-        logger.debug("Updated health context: \(metric.rawValue) = \(value)")
+        logger.debug("Updated local health context for \(metric.rawValue, privacy: .public)")
     }
     
     /// Get relevant health context for current conversation

--- a/S2Y/LLM/EnhancedLLMProvider+LocalModel.swift
+++ b/S2Y/LLM/EnhancedLLMProvider+LocalModel.swift
@@ -110,6 +110,8 @@ extension EnhancedLLMProvider {
         do {
             let response = try await sendMessage(message)
             return response.content
+        } catch is CancellationError {
+            return ""
         } catch {
             logger.error("Cloud model processing failed: \(error.localizedDescription)")
             

--- a/S2Y/LLM/EnhancedLLMProvider+LocalModel_Simplified.swift
+++ b/S2Y/LLM/EnhancedLLMProvider+LocalModel_Simplified.swift
@@ -102,6 +102,8 @@ extension EnhancedLLMProvider {
         do {
             let response = try await sendMessage(message)
             return response.content
+        } catch is CancellationError {
+            return ""
         } catch {
             extLogger.error("Cloud model processing failed: \(error.localizedDescription)")
             

--- a/S2Y/LLM/EnhancedLLMProvider.swift
+++ b/S2Y/LLM/EnhancedLLMProvider.swift
@@ -7,9 +7,10 @@
 
 // swiftlint:disable line_length force_cast
 
+import FirebaseAuth
 import Foundation
-import OSLog
 import Network
+import OSLog
 import Security
 
 /// Enhanced LLM provider with robust error handling and fallback mechanisms
@@ -25,7 +26,7 @@ public final class EnhancedLLMProvider: ObservableObject {
     @Published public private(set) var lastError: LLMError?
     @Published public private(set) var retryCount = 0
     
-    private let maxRetries = 3
+    private let maxRetries = 2
     private let baseRetryDelay: TimeInterval = 1.0
     private let contextManager = ConversationContextManager.shared
     
@@ -43,6 +44,10 @@ public final class EnhancedLLMProvider: ObservableObject {
         // Reset retry count for new requests
         retryCount = 0
         lastError = nil
+
+        if includeContext && UserDefaults.standard.bool(forKey: StorageKeys.shareHealthDataWithOmer) {
+            await refreshRelevantHealthContext(for: message)
+        }
         
         // Add message to context
         let contextMessage = ContextMessage(role: .user, content: message)
@@ -59,24 +64,15 @@ public final class EnhancedLLMProvider: ObservableObject {
         } catch let error as LLMError {
             lastError = error
             logger.error("LLM request failed: \(error.localizedDescription)")
-            
-            // Return fallback response
-            let fallbackResponse = generateFallbackResponse(for: message, error: error)
-            let fallbackMessage = ContextMessage(
-                role: .assistant, 
-                content: fallbackResponse.content,
-                metadata: MessageMetadata(intent: "fallback")
-            )
-            contextManager.addMessage(fallbackMessage)
-            
-            return fallbackResponse
+            throw error
         }
     }
     
     private func sendMessageWithRetry(
         _ message: String,
         includeContext: Bool,
-        attempt: Int = 1
+        attempt: Int = 1,
+        requestID: UUID = UUID()
     ) async throws -> LLMResponse {
         retryCount = attempt - 1
         
@@ -86,12 +82,12 @@ public final class EnhancedLLMProvider: ObservableObject {
                 throw LLMError.networkUnavailable
             }
             
-            // Prepare message with context
-            let finalMessage = includeContext ?
-                prepareMessageWithContext(message) : message
-
             // Perform real LLM request via provider with retry
-            let responseText = try await performLLMRequest(finalMessage)
+            let responseText = try await performLLMRequest(
+                message,
+                includeContext: includeContext,
+                requestID: requestID
+            )
 
             return LLMResponse(
                 content: responseText,
@@ -101,102 +97,165 @@ public final class EnhancedLLMProvider: ObservableObject {
                 contextUsed: includeContext
             )
             
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
-            logger.warning("LLM request attempt \(attempt) failed: \(error.localizedDescription)")
+            try Task.checkCancellation()
+            if let urlError = error as? URLError, urlError.code == .cancelled {
+                throw CancellationError()
+            }
+            let mappedError = mapToLLMError(error)
+            logger.warning("LLM request attempt \(attempt) failed: \(mappedError.localizedDescription)")
             
             // Determine if we should retry
-            if attempt < maxRetries && shouldRetry(error: error) {
+            if attempt < maxRetries && shouldRetry(error: mappedError) {
                 let delay = baseRetryDelay * pow(2.0, Double(attempt - 1)) // Exponential backoff
                 logger.info("Retrying LLM request after \(delay) seconds (attempt \(attempt + 1)/\(self.maxRetries))")
                 
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-                return try await sendMessageWithRetry(message, includeContext: includeContext, attempt: attempt + 1)
+                return try await sendMessageWithRetry(
+                    message,
+                    includeContext: includeContext,
+                    attempt: attempt + 1,
+                    requestID: requestID
+                )
             }
-            
-            // Convert to LLMError
-            throw mapToLLMError(error)
+            throw mappedError
         }
-    }
-    
-    private func prepareMessageWithContext(_ message: String) -> String {
-        let context = contextManager.getContextForLLM()
-        if context.isEmpty {
-            return message
-        }
-        
-        return """
-        Context from previous conversation:
-        \(context)
-        
-        Current user message:
-        \(message)
-        
-        Please respond considering the conversation context and any health data mentioned.
-        """
     }
     
     // MARK: - Provider integration
-    
-    private func performLLMRequest(_ message: String) async throws -> String {
-        // Load configuration
-        let (gatewayURL, modelPath) = try loadGatewayConfig()
-        let token = try loadBearerToken()
-        
-        // Build provider
-        let provider = CloudflareLLMProvider(gatewayURL: gatewayURL, modelPath: modelPath, token: token)
-        
-        // Compose messages: include minimal system guidance and the user message
-        let messages: [LLMMessage] = [
-            .init(role: .assistant, content: "You are a helpful health assistant. Keep responses concise, supportive, and avoid medical diagnosis."),
-            .init(role: .user, content: message)
-        ]
-        
+
+    private func refreshRelevantHealthContext(for message: String) async {
+        guard let intent = QueryPlanner.parse(message) else { return }
+        let metric: HealthKitService.MetricKind
+        switch intent {
+        case .compare(let kind, _), .trend(let kind, _):
+            metric = kind
+        }
+
         do {
-            // Optional timeout guard
-            return try await withThrowingTaskGroup(of: String.self) { group in
-                group.addTask {
-                    try await provider.complete(messages: messages)
-                }
-                // Simple timeout of 20s
-                group.addTask {
-                    try await Task.sleep(nanoseconds: 20_000_000_000)
-                    throw LLMError.requestTimeout
-                }
-                // First finished wins
-                let result = try await group.next()!
-                group.cancelAll()
-                return result
-            }
+            let summary = try await QueryPlanner.run(intent: intent)
+            contextManager.updateHealthContext(metric: metric, value: summary)
         } catch {
-            throw mapToLLMError(error)
+            logger.info("No shareable HealthKit summary was available for this request")
         }
     }
     
-    private func loadGatewayConfig() throws -> (String, String) {
+    private func performLLMRequest(_ message: String, includeContext: Bool, requestID: UUID) async throws -> String {
+        let (gatewayURL, modelPath, transport) = try loadServiceConfig()
+        let token = try await loadAccessToken(for: transport)
+
+        let client = OmerAPIClient(
+            configuration: .init(
+                gatewayURL: gatewayURL,
+                modelPath: modelPath,
+                bearerToken: token,
+                transport: transport
+            )
+        )
+
+        let messages = includeContext ? contextManager.currentContext.messages.map { contextMessage in
+            LLMMessage(
+                role: contextMessage.role == .assistant ? .assistant : .user,
+                content: contextMessage.content
+            )
+        } : [.init(role: .user, content: message)]
+        let response = try await client.complete(
+            query: message,
+            messages: messages,
+            healthContext: includeContext && UserDefaults.standard.bool(forKey: StorageKeys.shareHealthDataWithOmer)
+                ? contextManager.getRelevantHealthContext()
+                : [:],
+            conversationID: contextManager.currentContext.sessionId,
+            requestID: requestID
+        )
+        return formatOmerResponse(response)
+    }
+
+    private func formatOmerResponse(_ response: OmerAPIClient.Response) -> String {
+        var content = response.answer.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercased = content.lowercased()
+
+        if !lowercased.contains("medical diagnosis")
+            && !lowercased.contains("医疗诊断")
+            && !lowercased.contains("clinical diagnosis") {
+            content += "\n\n基于科学研究的健康建议，不构成医疗诊断。"
+        }
+
+        let citations = response.citations.prefix(3)
+        if !citations.isEmpty {
+            let sourceLines = citations.enumerated().map { index, citation in
+                let label = citation.title ?? citation.source ?? "Source \(index + 1)"
+                if let url = citation.url {
+                    return "\(index + 1). \(label) - \(url)"
+                }
+                return "\(index + 1). \(label)"
+            }
+            content += "\n\nSources:\n" + sourceLines.joined(separator: "\n")
+        }
+
+        return content
+    }
+    
+    private func loadServiceConfig() throws -> (String, String, OmerTransport) {
         let defaults = UserDefaults.standard
-        let bundledGatewayURL = (Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.GatewayURL") as? String)?
+        let bundledTransport = Bundle.main.object(forInfoDictionaryKey: "Omer.Transport") as? String
+        let transportValue = defaults.string(forKey: StorageKeys.omerTransport) ?? bundledTransport
+        let transport = OmerTransport(rawValue: transportValue ?? "") ?? .legacyAutoRAG
+        let keys: (gateway: String, path: String, bundledGateway: String, bundledPath: String) = switch transport {
+        case .mobileV1:
+            (
+                StorageKeys.omerMobileGatewayURL,
+                StorageKeys.omerMobileModelPath,
+                "Omer.MobileGatewayURL",
+                "Omer.MobileModelPath"
+            )
+        case .legacyAutoRAG:
+            (
+                StorageKeys.cloudflareGatewayURL,
+                StorageKeys.cloudflareModelPath,
+                "CFWorkersAI.GatewayURL",
+                "CFWorkersAI.ModelPath"
+            )
+        }
+        let bundledGatewayURL = (Bundle.main.object(forInfoDictionaryKey: keys.bundledGateway) as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let bundledModelPath = (Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.ModelPath") as? String)?
+        let bundledModelPath = (Bundle.main.object(forInfoDictionaryKey: keys.bundledPath) as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let gatewayURL = (defaults.string(forKey: StorageKeys.cloudflareGatewayURL) ?? bundledGatewayURL)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let modelPath = (defaults.string(forKey: StorageKeys.cloudflareModelPath) ?? bundledModelPath)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedGatewayURL = defaults.string(forKey: keys.gateway)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let storedModelPath = defaults.string(forKey: keys.path)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let gatewayURL = storedGatewayURL.isEmpty ? bundledGatewayURL : storedGatewayURL
+        let modelPath = storedModelPath.isEmpty ? bundledModelPath : storedModelPath
         guard !gatewayURL.isEmpty else { throw LLMError.apiKeyMissing }
-        return (gatewayURL, modelPath)
+        return (gatewayURL, modelPath, transport)
+    }
+
+    private func loadAccessToken(for transport: OmerTransport) async throws -> String {
+        switch transport {
+        case .mobileV1:
+            guard let user = Auth.auth().currentUser else { throw LLMError.authenticationFailed }
+            do {
+                return try await user.getIDToken(forcingRefresh: false)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                throw LLMError.authenticationFailed
+            }
+        case .legacyAutoRAG:
+            return try loadBearerToken()
+        }
     }
     
     private func loadBearerToken() throws -> String {
-        // Try HealthAssistant keychain style (account only)
-        if let token = readKeychainAccountOnly(account: "gateway.token"), !token.isEmpty {
-            return token
-        }
-        // Try demo keychain style (service + account)
+        // Prefer the service-scoped item written by current settings.
         if let token = readKeychain(service: "ai.cloudflare", account: "gateway.token"), !token.isEmpty {
             return token
         }
-        // Fallback to Info.plist
-        if let token = Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.BearerToken") as? String, !token.isEmpty {
+        // Preserve compatibility with older app builds.
+        if let token = readKeychainAccountOnly(account: "gateway.token"), !token.isEmpty {
             return token
         }
         throw LLMError.apiKeyMissing
@@ -297,10 +356,12 @@ public final class EnhancedLLMProvider: ObservableObject {
         // Don't retry certain types of errors
         if let llmError = error as? LLMError {
             switch llmError {
-            case .apiKeyMissing, .authenticationFailed, .invalidResponse:
+            case .apiKeyMissing, .authenticationFailed, .invalidResponse, .rateLimited:
                 return false
-            case .networkUnavailable, .requestTimeout, .rateLimited, .serverError, .unknown:
+            case .networkUnavailable, .requestTimeout, .serverError:
                 return true
+            case .unknown:
+                return false
             }
         }
         
@@ -324,7 +385,7 @@ public final class EnhancedLLMProvider: ObservableObject {
                 if code == 408 { return .requestTimeout }
                 if code == 429 { return .rateLimited }
                 if (500..<600).contains(code) { return .serverError(code) }
-                return .unknown(error)
+                return .invalidResponse
             }
         }
         

--- a/S2Y/LLM/LLMProvider.swift
+++ b/S2Y/LLM/LLMProvider.swift
@@ -12,7 +12,7 @@ import Foundation
 
 
 public struct LLMMessage: Sendable {
-    public enum Role: String, Sendable { case user, assistant }
+    public enum Role: String, Sendable { case system, user, assistant }
     public let role: Role
     public let content: String
     public init(role: Role, content: String) {
@@ -57,79 +57,14 @@ public struct CloudflareLLMProvider: LLMProvider, Sendable {
     }
 
     public func complete(messages: [LLMMessage]) async throws -> String {
-        let (url, useQueryField) = try buildURL(gatewayURL: gatewayURL, modelPath: modelPath)
-        let (prompt, lastUser) = composePrompts(messages)
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try encodeBody(useQueryField: useQueryField, prompt: prompt, lastUserMessage: lastUser)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
-        guard (200..<300).contains(http.statusCode) else {
-            let text = String(data: data, encoding: .utf8) ?? ""
-            throw LLMProviderError.httpStatus(code: http.statusCode, body: text)
-        }
-        return try parseReply(data)
-    }
-
-    private func buildURL(gatewayURL: String, modelPath: String) throws -> (URL, Bool) {
-        var base = gatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        if base.hasSuffix("/") { base.removeLast() }
-        var path = modelPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        if path.hasPrefix("/") { path.removeFirst() }
-        let full = path.isEmpty ? base : (base + "/" + path)
-        guard let url = URL(string: full) else { throw LLMProviderError.badURL }
-        return (url, full.contains("ai-search"))
-    }
-
-    private func composePrompts(_ messages: [LLMMessage]) -> (prompt: String, lastUser: String) {
         let lastUser = messages.last(where: { $0.role == .user })?.content ?? messages.last?.content ?? ""
-        let prompt = messages.map { msg in
-            switch msg.role {
-            case .user: return "User: \(msg.content)"
-            case .assistant: return "Assistant: \(msg.content)"
-            }
-        }.joined(separator: "\n")
-        return (prompt, lastUser)
-    }
-
-    private func encodeBody(useQueryField: Bool, prompt: String, lastUserMessage: String) throws -> Data {
-        struct CFPayloadPrompt: Codable { let prompt: String }
-        struct CFPayloadQuery: Codable { let query: String }
-        if useQueryField {
-            return try JSONEncoder().encode(CFPayloadQuery(query: lastUserMessage))
-        } else {
-            return try JSONEncoder().encode(CFPayloadPrompt(prompt: prompt))
-        }
-    }
-
-    private func parseReply(_ data: Data) throws -> String {
-        struct CFResult: Codable {
-            let response: String?
-            let text: String?
-            let outputText: String?
-            let answer: String?
-            enum CodingKeys: String, CodingKey {
-                case response
-                case text
-                case outputText = "output_text"
-                case answer
-            }
-        }
-        struct CFResponse: Codable { let result: CFResult?; let success: Bool? }
-
-        guard let decoded = try? JSONDecoder().decode(CFResponse.self, from: data) else {
-            throw LLMProviderError.decodingFailed
-        }
-        let reply = decoded.result?.response
-            ?? decoded.result?.text
-            ?? decoded.result?.outputText
-            ?? decoded.result?.answer
-            ?? ""
-        return reply.trimmingCharacters(in: .whitespacesAndNewlines)
+        let client = OmerAPIClient(
+            configuration: .init(
+                gatewayURL: gatewayURL,
+                modelPath: modelPath,
+                bearerToken: token
+            )
+        )
+        return try await client.complete(query: lastUser, messages: messages).answer
     }
 }
-

--- a/S2Y/LLM/OmerAPIClient.swift
+++ b/S2Y/LLM/OmerAPIClient.swift
@@ -1,0 +1,301 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+
+// swiftlint:disable file_length type_body_length
+
+import Foundation
+
+enum OmerTransport: String, CaseIterable, Sendable {
+    case mobileV1 = "omer-mobile-v1"
+    case legacyAutoRAG = "legacy-autorag"
+}
+
+struct OmerAPIClient: Sendable {
+    struct Configuration: Sendable {
+        let gatewayURL: String
+        let modelPath: String
+        let bearerToken: String
+        let transport: OmerTransport
+        let timeout: TimeInterval
+
+        init(
+            gatewayURL: String,
+            modelPath: String,
+            bearerToken: String,
+            transport: OmerTransport = .legacyAutoRAG,
+            timeout: TimeInterval = 45
+        ) {
+            self.gatewayURL = gatewayURL
+            self.modelPath = modelPath
+            self.bearerToken = bearerToken
+            self.transport = transport
+            self.timeout = timeout
+        }
+    }
+
+    struct Response: Sendable, Equatable {
+        let answer: String
+        let citations: [Citation]
+        let conversationID: UUID?
+        let requestID: UUID?
+
+        init(answer: String, citations: [Citation], conversationID: UUID? = nil, requestID: UUID? = nil) {
+            self.answer = answer
+            self.citations = citations
+            self.conversationID = conversationID
+            self.requestID = requestID
+        }
+    }
+
+    struct Citation: Codable, Sendable, Equatable {
+        let title: String?
+        let url: String?
+        let source: String?
+        let snippet: String?
+
+        init(title: String? = nil, url: String? = nil, source: String? = nil, snippet: String? = nil) {
+            self.title = title?.nilIfBlank
+            self.url = url?.nilIfBlank
+            self.source = source?.nilIfBlank
+            self.snippet = snippet?.nilIfBlank
+        }
+    }
+
+    private struct MobileChatRequest: Encodable {
+        struct Message: Encodable {
+            let id: UUID
+            let text: String
+        }
+
+        struct HistoryMessage: Encodable {
+            let role: String
+            let content: String
+        }
+
+        struct Client: Encodable {
+            let platform: String
+            let version: String
+        }
+
+        let requestId: UUID
+        let conversationId: UUID
+        let message: Message
+        let history: [HistoryMessage]
+        let locale: String
+        let healthContext: [String: String]?
+        let client: Client
+    }
+
+    private struct MobileChatResponse: Decodable {
+        let requestId: UUID
+        let conversationId: UUID
+        let answer: String
+        let citations: [Citation]
+    }
+
+    private let configuration: Configuration
+    private let session: URLSession
+
+    init(configuration: Configuration, session: URLSession = .shared) {
+        self.configuration = configuration
+        self.session = session
+    }
+
+    func complete(
+        query: String,
+        messages: [LLMMessage],
+        healthContext: [String: String] = [:],
+        conversationID: UUID = UUID(),
+        requestID: UUID = UUID()
+    ) async throws -> Response {
+        let request = try Self.makeRequest(
+            configuration: configuration,
+            query: query,
+            messages: messages,
+            healthContext: healthContext,
+            conversationID: conversationID,
+            requestID: requestID
+        )
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        guard (200..<300).contains(http.statusCode) else {
+            let text = String(data: data.prefix(8_192), encoding: .utf8) ?? ""
+            throw LLMProviderError.httpStatus(code: http.statusCode, body: text)
+        }
+
+        switch configuration.transport {
+        case .mobileV1:
+            return try Self.decodeMobileResponse(data, expectedRequestID: requestID)
+        case .legacyAutoRAG:
+            return try Self.decodeLegacyResponse(data)
+        }
+    }
+
+    static func makeRequest(
+        configuration: Configuration,
+        query: String,
+        messages: [LLMMessage],
+        healthContext: [String: String],
+        conversationID: UUID,
+        requestID: UUID
+    ) throws -> URLRequest {
+        let url = try buildURL(gatewayURL: configuration.gatewayURL, modelPath: configuration.modelPath)
+        if configuration.transport == .mobileV1 {
+            try validateMobileURL(url)
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: configuration.timeout)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let token = configuration.bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !token.isEmpty {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        switch configuration.transport {
+        case .mobileV1:
+            guard !token.isEmpty else { throw LLMError.authenticationFailed }
+            request.addValue(requestID.uuidString, forHTTPHeaderField: "Idempotency-Key")
+            request.httpBody = try encodeMobileRequest(
+                query: query,
+                messages: messages,
+                healthContext: healthContext,
+                conversationID: conversationID,
+                requestID: requestID
+            )
+        case .legacyAutoRAG:
+            guard !token.isEmpty else { throw LLMError.apiKeyMissing }
+            request.httpBody = try JSONEncoder().encode(["query": query])
+        }
+        return request
+    }
+
+    static func buildURL(gatewayURL: String, modelPath: String) throws -> URL {
+        var base = gatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.hasSuffix("/") {
+            base.removeLast()
+        }
+
+        var path = modelPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if path.hasPrefix("/") {
+            path.removeFirst()
+        }
+
+        let fullURL = path.isEmpty ? base : "\(base)/\(path)"
+        guard let url = URL(string: fullURL), url.host != nil else { throw LLMProviderError.badURL }
+        return url
+    }
+
+    static func encodeMobileRequest(
+        query: String,
+        messages: [LLMMessage],
+        healthContext: [String: String],
+        conversationID: UUID,
+        requestID: UUID
+    ) throws -> Data {
+        let history = messages
+            .filter { $0.role == .user || $0.role == .assistant }
+            .dropLast(messages.last?.role == .user ? 1 : 0)
+            .suffix(10)
+            .map { MobileChatRequest.HistoryMessage(role: $0.role.rawValue, content: String($0.content.prefix(2_000))) }
+        let context = healthContext.isEmpty ? nil : Dictionary(
+            uniqueKeysWithValues: healthContext.prefix(10).map { key, value in
+                (String(key.prefix(64)), String(value.prefix(200)))
+            }
+        )
+        let payload = MobileChatRequest(
+            requestId: requestID,
+            conversationId: conversationID,
+            message: .init(id: requestID, text: String(query.prefix(2_000))),
+            history: history,
+            locale: Locale.current.identifier,
+            healthContext: context,
+            client: .init(platform: "ios", version: appVersion)
+        )
+        return try JSONEncoder().encode(payload)
+    }
+
+    static func decodeMobileResponse(_ data: Data, expectedRequestID: UUID) throws -> Response {
+        guard data.count <= 1_048_576,
+              let decoded = try? JSONDecoder().decode(MobileChatResponse.self, from: data),
+              decoded.requestId == expectedRequestID,
+              let answer = decoded.answer.nilIfBlank else {
+            throw LLMProviderError.decodingFailed
+        }
+        return Response(
+            answer: answer,
+            citations: Array(decoded.citations.prefix(5)),
+            conversationID: decoded.conversationId,
+            requestID: decoded.requestId
+        )
+    }
+
+    static func decodeLegacyResponse(_ data: Data) throws -> Response {
+        guard data.count <= 1_048_576,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["success"] as? Bool != false,
+              let answer = findAnswer(in: object)?.nilIfBlank else {
+            throw LLMProviderError.decodingFailed
+        }
+        return Response(answer: answer, citations: findCitations(in: object))
+    }
+
+    private static func validateMobileURL(_ url: URL) throws {
+        guard url.scheme?.lowercased() == "https" else { throw LLMProviderError.badURL }
+    }
+
+    private static var userAgent: String {
+        "S2Y-iOS/\(appVersion)"
+    }
+
+    private static var appVersion: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        let components = [version, build].compactMap { $0?.nilIfBlank }
+        return components.joined(separator: ".").nilIfBlank ?? "unknown"
+    }
+
+    private static func findAnswer(in dictionary: [String: Any]) -> String? {
+        if let result = dictionary["result"] as? [String: Any] {
+            return stringValue(in: result, keys: ["response", "answer", "text", "output_text"])
+        }
+        return stringValue(in: dictionary, keys: ["response", "answer", "text", "output_text"])
+    }
+
+    private static func findCitations(in dictionary: [String: Any]) -> [Citation] {
+        let result = dictionary["result"] as? [String: Any]
+        let values = result?["data"] ?? result?["citations"] ?? dictionary["citations"]
+        return Array(decodeCitations(from: values).prefix(5))
+    }
+
+    private static func decodeCitations(from value: Any?) -> [Citation] {
+        guard let values = value as? [[String: Any]] else { return [] }
+        return values.compactMap { dictionary in
+            let citation = Citation(
+                title: stringValue(in: dictionary, keys: ["title", "name"]),
+                url: stringValue(in: dictionary, keys: ["url", "href", "link"]),
+                source: stringValue(in: dictionary, keys: ["source", "file", "document"]),
+                snippet: stringValue(in: dictionary, keys: ["snippet", "summary", "content", "text"])
+            )
+            return citation.title == nil && citation.url == nil && citation.source == nil && citation.snippet == nil ? nil : citation
+        }
+    }
+
+    private static func stringValue(in dictionary: [String: Any], keys: [String]) -> String? {
+        keys.lazy.compactMap { (dictionary[$0] as? String)?.nilIfBlank }.first
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/S2Y/SharedContext/StorageKeys.swift
+++ b/S2Y/SharedContext/StorageKeys.swift
@@ -32,6 +32,14 @@ enum StorageKeys {
     static let cloudflareGatewayURL = "cf.gateway-url"
     /// Device-level override for the Cloudflare AI model path. Empty = bundled default.
     static let cloudflareModelPath = "cf.model-path"
+    /// Device-level override for the Omer Mobile API base URL. Empty = bundled default.
+    static let omerMobileGatewayURL = "omer.mobile.gateway-url"
+    /// Device-level override for the Omer Mobile API route. Empty = bundled default.
+    static let omerMobileModelPath = "omer.mobile.model-path"
+    /// Explicit Omer transport protocol. Empty = bundled default.
+    static let omerTransport = "omer.transport"
+    /// Allow selected HealthKit summaries to be sent to Omer.
+    static let shareHealthDataWithOmer = "omer.share-health-data"
     /// Enable or disable voice features globally
     static let voiceEnabled = "voice.enabled"
     /// Speak assistant responses using TTS

--- a/S2Y/Supporting Files/Info.plist
+++ b/S2Y/Supporting Files/Info.plist
@@ -22,12 +22,16 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>CFWorkersAI.BearerToken</key>
-	<string></string>
 	<key>CFWorkersAI.GatewayURL</key>
 	<string>https://api.cloudflare.com/client/v4/accounts/115e03820979674efcc9baa1d9fcd081/autorag/rags/s2y-ai-omer/ai-search</string>
 	<key>CFWorkersAI.ModelPath</key>
 	<string></string>
+	<key>Omer.Transport</key>
+	<string>omer-mobile-v1</string>
+	<key>Omer.MobileGatewayURL</key>
+	<string>https://s2y-omer.vercel.app</string>
+	<key>Omer.MobileModelPath</key>
+	<string>/api/mobile/v1/chat</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/S2YTests/OmerAPIClientTests.swift
+++ b/S2YTests/OmerAPIClientTests.swift
@@ -1,0 +1,180 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import S2Y
+import Foundation
+import Testing
+
+
+@Suite("Omer API Client Tests")
+struct OmerAPIClientTests {
+    @Test("Decodes Cloudflare AutoRAG response")
+    func decodesCloudflareAutoRAGResponse() throws {
+        let data = try #require("""
+        {
+          "success": true,
+          "result": {
+            "response": "Pacing can help reduce post-exertional symptom flares.",
+            "data": [
+              {
+                "title": "Long COVID pacing guide",
+                "url": "https://example.com/pacing",
+                "content": "Use an energy envelope and rest before symptoms worsen."
+              }
+            ]
+          }
+        }
+        """.data(using: .utf8))
+
+        let response = try OmerAPIClient.decodeLegacyResponse(data)
+
+        #expect(response.answer == "Pacing can help reduce post-exertional symptom flares.")
+        #expect(response.citations.first?.title == "Long COVID pacing guide")
+        #expect(response.citations.first?.url == "https://example.com/pacing")
+    }
+
+    @Test("Rejects unsuccessful AutoRAG response")
+    func rejectsUnsuccessfulAutoRAGResponse() throws {
+        let data = try #require("""
+        { "success": false, "result": { "response": "not an answer" } }
+        """.data(using: .utf8))
+
+        #expect(throws: LLMProviderError.self) {
+            try OmerAPIClient.decodeLegacyResponse(data)
+        }
+    }
+
+    @Test("Encodes Mobile API request and authentication")
+    func encodesMobileAPIRequest() throws {
+        let requestID = try #require(UUID(uuidString: "B931A06B-137F-4CD0-A984-7E37029F7F21"))
+        let conversationID = try #require(UUID(uuidString: "DE9D8062-7285-451A-BF99-6329E79038F7"))
+        let request = try OmerAPIClient.makeRequest(
+            configuration: .init(
+                gatewayURL: "https://omer.example.com",
+                modelPath: "/api/mobile/v1/chat",
+                bearerToken: "firebase-id-token",
+                transport: .mobileV1
+            ),
+            query: "What helps with PEM?",
+            messages: [
+                .init(role: .system, content: "untrusted system prompt"),
+                .init(role: .user, content: "Earlier question"),
+                .init(role: .assistant, content: "Earlier answer"),
+                .init(role: .user, content: "What helps with PEM?")
+            ],
+            healthContext: ["restingHeartRate": "88 bpm"],
+            conversationID: conversationID,
+            requestID: requestID
+        )
+
+        #expect(request.url?.absoluteString == "https://omer.example.com/api/mobile/v1/chat")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer firebase-id-token")
+        #expect(request.value(forHTTPHeaderField: "Idempotency-Key") == requestID.uuidString)
+
+        let data = try #require(request.httpBody)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["requestId"] as? String == requestID.uuidString.uppercased())
+        #expect(object["conversationId"] as? String == conversationID.uuidString.uppercased())
+        #expect((object["history"] as? [[String: Any]])?.count == 2)
+        #expect((object["history"] as? [[String: Any]])?.contains { $0["role"] as? String == "system" } == false)
+        #expect((object["healthContext"] as? [String: String])?["restingHeartRate"] == "88 bpm")
+    }
+
+    @Test("Decodes strict Mobile API response")
+    func decodesMobileAPIResponse() throws {
+        let requestID = try #require(UUID(uuidString: "B931A06B-137F-4CD0-A984-7E37029F7F21"))
+        let data = try #require("""
+        {
+          "requestId": "B931A06B-137F-4CD0-A984-7E37029F7F21",
+          "conversationId": "DE9D8062-7285-451A-BF99-6329E79038F7",
+          "answer": "Use pacing and stay within your energy envelope.",
+          "citations": [{"title":"Pacing guide","url":"https://example.com/pacing"}]
+        }
+        """.data(using: .utf8))
+
+        let response = try OmerAPIClient.decodeMobileResponse(data, expectedRequestID: requestID)
+
+        #expect(response.requestID == requestID)
+        #expect(response.answer.contains("energy envelope"))
+        #expect(response.citations.first?.title == "Pacing guide")
+    }
+
+    @Test("Rejects Mobile API response for another request")
+    func rejectsMismatchedMobileResponse() throws {
+        let data = try #require("""
+        {
+          "requestId": "B931A06B-137F-4CD0-A984-7E37029F7F21",
+          "conversationId": "DE9D8062-7285-451A-BF99-6329E79038F7",
+          "answer": "Answer",
+          "citations": []
+        }
+        """.data(using: .utf8))
+
+        #expect(throws: LLMProviderError.self) {
+            try OmerAPIClient.decodeMobileResponse(data, expectedRequestID: UUID())
+        }
+    }
+
+    @Test("Encodes legacy AutoRAG as query only")
+    func encodesLegacyAutoRAGRequest() throws {
+        let request = try OmerAPIClient.makeRequest(
+            configuration: .init(
+                gatewayURL: "https://api.cloudflare.com/client/v4/accounts/example/autorag/rags/s2y-ai-omer/ai-search",
+                modelPath: "",
+                bearerToken: "token",
+                transport: .legacyAutoRAG
+            ),
+            query: "What helps with PEM?",
+            messages: [.init(role: .user, content: "ignored")],
+            healthContext: ["heartRate": "88 bpm"],
+            conversationID: UUID(),
+            requestID: UUID()
+        )
+
+        let data = try #require(request.httpBody)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+        #expect(object == ["query": "What helps with PEM?"])
+    }
+
+    @Test("Mobile API requires HTTPS and authentication")
+    func validatesMobileSecurityRequirements() throws {
+        let insecureConfiguration = OmerAPIClient.Configuration(
+            gatewayURL: "http://omer.example.com",
+            modelPath: "/api/mobile/v1/chat",
+            bearerToken: "token",
+            transport: .mobileV1
+        )
+        #expect(throws: LLMProviderError.self) {
+            try OmerAPIClient.makeRequest(
+                configuration: insecureConfiguration,
+                query: "Question",
+                messages: [],
+                healthContext: [:],
+                conversationID: UUID(),
+                requestID: UUID()
+            )
+        }
+
+        let unauthenticatedConfiguration = OmerAPIClient.Configuration(
+            gatewayURL: "https://omer.example.com",
+            modelPath: "/api/mobile/v1/chat",
+            bearerToken: "",
+            transport: .mobileV1
+        )
+        #expect(throws: LLMError.self) {
+            try OmerAPIClient.makeRequest(
+                configuration: unauthenticatedConfiguration,
+                query: "Question",
+                messages: [],
+                healthContext: [:],
+                conversationID: UUID(),
+                requestID: UUID()
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a typed Omer mobile API client with strict response validation and stable request IDs
- authenticate requests with the signed-in Firebase user ID token
- send bounded conversation history and opt-in relevant health summaries
- keep legacy Cloudflare AutoRAG as an explicitly separate compatibility transport
- add cancellation handling, local fallback signaling, scoped Keychain storage, and settings controls
- remove sensitive message and health values from OSLog output
- add focused Omer client request/response tests

## Dependency and rollout

Depends on javenisme/s2y-omer#2. Merge and deploy the server PR first because the app defaults to `https://s2y-omer.vercel.app/api/mobile/v1/chat`.

## Verification

- GitHub Actions Fastlane build and test passed: https://github.com/javenisme/s2y-app-iOS/actions/runs/30644902780
- validated HTTPS-only mobile endpoints and Firebase Bearer requirements
- verified request IDs are reused across retries and echoed by the service
- verified health sharing remains disabled unless explicitly enabled