### PR TITLE
Sync Health Assistant history with Omer

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -59,6 +59,10 @@ struct HealthAssistantView: View {
     @State private var isProcessing = false
     @State private var notice: AssistantNotice?
     @State private var showingSettings = false
+    @State private var showingHistory = false
+    @State private var chatHistory: [OmerChatSummary] = []
+    @State private var isLoadingHistory = false
+    @State private var historyError: String?
     @State private var streamTick = 0
     @State private var pendingToolApproval: OmerToolApprovalPayload?
     @AppStorage(StorageKeys.omerIncludeHealthContext) private var omerIncludeHealthContext = true
@@ -84,7 +88,14 @@ struct HealthAssistantView: View {
             .navigationTitle("Health Assistant")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button {
+                        showingHistory = true
+                    } label: {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .accessibilityLabel("Conversation History")
+                    }
+
                     Button {
                         showingSettings = true
                     } label: {
@@ -97,6 +108,12 @@ struct HealthAssistantView: View {
                 NavigationStack {
                     HealthAssistantSettingsView(showsDismissButton: true)
                 }
+            }
+            .sheet(isPresented: $showingHistory) {
+                conversationHistorySheet
+                    .task {
+                        await loadConversationHistory()
+                    }
             }
         }
         .task {
@@ -113,6 +130,108 @@ struct HealthAssistantView: View {
                     Task { await decideTool(approval, approved: false) }
                 }
             )
+        }
+    }
+
+    private var conversationHistorySheet: some View {
+        NavigationStack {
+            Group {
+                if isLoadingHistory && chatHistory.isEmpty {
+                    ProgressView("Loading conversations…")
+                } else if let historyError, chatHistory.isEmpty {
+                    ContentUnavailableView(
+                        "History Unavailable",
+                        systemImage: "exclamationmark.bubble",
+                        description: Text(historyError)
+                    )
+                } else if chatHistory.isEmpty {
+                    ContentUnavailableView(
+                        "No Conversations Yet",
+                        systemImage: "bubble.left.and.bubble.right",
+                        description: Text("Chats from S2Y Home and this iPhone will appear here.")
+                    )
+                } else {
+                    List(chatHistory) { chat in
+                        Button {
+                            Task { await openConversation(chat) }
+                        } label: {
+                            VStack(alignment: .leading, spacing: 5) {
+                                Text(chat.title)
+                                    .font(.headline)
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(2)
+                                Text("Synced with S2Y")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .refreshable {
+                        await loadConversationHistory()
+                    }
+                }
+            }
+            .navigationTitle("Conversations")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { showingHistory = false }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await beginNewConversation() }
+                    } label: {
+                        Label("New Chat", systemImage: "square.and.pencil")
+                    }
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func loadConversationHistory() async {
+        isLoadingHistory = true
+        historyError = nil
+        defer { isLoadingHistory = false }
+        do {
+            chatHistory = try await omerChatService.fetchChats().chats
+        } catch {
+            historyError = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func openConversation(_ chat: OmerChatSummary) async {
+        isLoadingHistory = true
+        historyError = nil
+        do {
+            let detail = try await omerChatService.fetchChat(id: chat.id)
+            try await omerChatService.selectChat(id: chat.id)
+            messages = detail.messages.compactMap { message in
+                guard !message.content.isEmpty else { return nil }
+                return ChatMessage(
+                    id: message.id,
+                    role: message.role == "user" ? .user : .assistant,
+                    content: message.content
+                )
+            }
+            showingHistory = false
+        } catch {
+            historyError = error.localizedDescription
+        }
+        isLoadingHistory = false
+    }
+
+    @MainActor
+    private func beginNewConversation() async {
+        do {
+            try await omerChatService.startNewChat()
+            messages = []
+            notice = nil
+            showingHistory = false
+        } catch {
+            historyError = error.localizedDescription
         }
     }
 
@@ -316,6 +435,23 @@ struct HealthAssistantView: View {
                 ) { snapshot in
                     updateAssistantMessage(id: assistantPlaceholder.id, content: snapshot)
                 }
+                if let assistantText = messages.first(where: { $0.id == assistantPlaceholder.id })?.content,
+                   !assistantText.isEmpty {
+                    do {
+                        _ = try await omerChatService.syncOnDeviceExchange(
+                            userMessageID: userMessage.id,
+                            userText: query,
+                            assistantMessageID: assistantPlaceholder.id,
+                            assistantText: assistantText
+                        )
+                    } catch {
+                        logger.error("On-device chat sync failed: \(error.localizedDescription)")
+                        notice = AssistantNotice(
+                            message: "The answer is available on this iPhone, but could not sync to your S2Y history yet.",
+                            tone: .warning
+                        )
+                    }
+                }
                 isProcessing = false
                 return
             } catch {
@@ -372,6 +508,11 @@ struct HealthAssistantView: View {
             pendingToolApproval = approval
         case .toolResult(let toolName):
             appendAssistantDelta(id: assistantMessageID, delta: "\n\n✓ \(toolName) completed.")
+        case .billing(let billing):
+            notice = AssistantNotice(
+                message: "\(billing.plan.capitalized) plan · \(billing.remainingTokens.formatted()) AI tokens remaining this month.",
+                tone: .info
+            )
         case .error(let message):
             updateAssistantMessage(id: assistantMessageID, content: message)
         }

--- a/S2Y/LLM/Omer/OmerChatModels.swift
+++ b/S2Y/LLM/Omer/OmerChatModels.swift
@@ -39,7 +39,34 @@ struct OmerMobileChatResponse: Decodable {
     let conversationId: UUID
     let requestId: UUID
     let agentId: String
+    let billing: OmerBillingStatus?
     let toolEvents: [ToolEvent]
+}
+
+struct OmerBillingStatus: Decodable, Equatable, Sendable {
+    let plan: String
+    let usedTokens: Int
+    let monthlyTokenLimit: Int
+    let remainingTokens: Int
+}
+
+struct OmerLocalChatSyncRequest: Encodable {
+    struct Message: Encodable {
+        let id: UUID
+        let role: String
+        let content: String
+    }
+
+    let requestId: UUID
+    let conversationId: UUID
+    let source: String
+    let messages: [Message]
+}
+
+struct OmerLocalChatSyncResponse: Decodable {
+    let requestId: UUID
+    let conversationId: UUID
+    let synced: Bool
 }
 
 struct OmerToolDecisionRequest: Encodable {
@@ -67,6 +94,30 @@ struct OmerAgent: Decodable, Identifiable, Sendable {
 
 struct OmerAgentsResponse: Decodable {
     let agents: [OmerAgent]
+}
+
+struct OmerChatSummary: Decodable, Identifiable, Sendable {
+    let id: UUID
+    let createdAt: String
+    let title: String
+    let visibility: String
+}
+
+struct OmerChatListResponse: Decodable, Sendable {
+    let chats: [OmerChatSummary]
+    let hasMore: Bool
+}
+
+struct OmerChatHistoryMessage: Decodable, Identifiable, Sendable {
+    let id: UUID
+    let role: String
+    let content: String
+    let createdAt: String
+}
+
+struct OmerChatDetailResponse: Decodable, Sendable {
+    let chat: OmerChatSummary
+    let messages: [OmerChatHistoryMessage]
 }
 
 struct OmerAPIErrorResponse: Decodable {
@@ -102,6 +153,7 @@ enum OmerChatStreamEvent: Equatable, Sendable {
     case completed(OmerCompletedPayload)
     case toolApprovalRequired(OmerToolApprovalPayload)
     case toolResult(String)
+    case billing(OmerBillingStatus)
     case error(String)
 }
 

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -28,7 +28,7 @@ actor OmerChatService {
         onEvent: @escaping @Sendable (OmerChatStreamEvent) -> Void
     ) async throws {
         let serviceURL = try configuredServiceURL()
-        let sessionKey = "\(serviceURL.absoluteString)|firebase-v1"
+        let sessionKey = sessionKey(for: serviceURL)
         let conversationID = await existingOrNewConversationID(sessionKey: sessionKey)
         let requestID = UUID()
         let healthContext = await OmerHealthContextBuilder.buildSummary(
@@ -82,6 +82,9 @@ actor OmerChatService {
                 onEvent(.toolResult(toolEvent.toolName))
             }
         }
+        if let billing = response.billing {
+            onEvent(.billing(billing))
+        }
         await sessionStore.saveLastChatId(response.conversationId.uuidString, sessionKey: sessionKey)
         onEvent(.completed(.init(
             chatId: response.conversationId.uuidString,
@@ -117,6 +120,70 @@ actor OmerChatService {
         return try decoder.decode(OmerAgentsResponse.self, from: data).agents
     }
 
+    func fetchChats(limit: Int = 20, before: UUID? = nil) async throws -> OmerChatListResponse {
+        let serviceURL = try configuredServiceURL()
+        var components = URLComponents(
+            url: serviceURL.appendingPathComponent("api/mobile/v1/chats"),
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = [
+            URLQueryItem(name: "limit", value: String(min(max(limit, 1), 50)))
+        ] + (before.map { [URLQueryItem(name: "before", value: $0.uuidString)] } ?? [])
+        guard let url = components?.url else {
+            throw OmerChatServiceError.invalidBaseURL
+        }
+        let data = try await authenticatedGET(url: url)
+        return try decoder.decode(OmerChatListResponse.self, from: data)
+    }
+
+    func fetchChat(id: UUID) async throws -> OmerChatDetailResponse {
+        let serviceURL = try configuredServiceURL()
+        let url = serviceURL
+            .appendingPathComponent("api/mobile/v1/chats")
+            .appendingPathComponent(id.uuidString)
+        let data = try await authenticatedGET(url: url)
+        return try decoder.decode(OmerChatDetailResponse.self, from: data)
+    }
+
+    func selectChat(id: UUID) async throws {
+        let serviceURL = try configuredServiceURL()
+        await sessionStore.saveLastChatId(id.uuidString, sessionKey: sessionKey(for: serviceURL))
+    }
+
+    func startNewChat() async throws {
+        let serviceURL = try configuredServiceURL()
+        await sessionStore.saveLastChatId(nil, sessionKey: sessionKey(for: serviceURL))
+    }
+
+    func syncOnDeviceExchange(
+        userMessageID: UUID,
+        userText: String,
+        assistantMessageID: UUID,
+        assistantText: String
+    ) async throws -> OmerLocalChatSyncResponse {
+        let serviceURL = try configuredServiceURL()
+        let key = sessionKey(for: serviceURL)
+        let conversationID = await existingOrNewConversationID(sessionKey: key)
+        let request = OmerLocalChatSyncRequest(
+            requestId: UUID(),
+            conversationId: conversationID,
+            source: "ios-on-device",
+            messages: [
+                .init(id: userMessageID, role: "user", content: userText),
+                .init(id: assistantMessageID, role: "assistant", content: assistantText)
+            ]
+        )
+        let url = serviceURL.appendingPathComponent("api/mobile/v1/chats/sync")
+        let response: OmerLocalChatSyncResponse
+        do {
+            response = try await performLocalSync(request, url: url, forceTokenRefresh: false)
+        } catch OmerChatServiceError.unauthorized {
+            response = try await performLocalSync(request, url: url, forceTokenRefresh: true)
+        }
+        await sessionStore.saveLastChatId(response.conversationId.uuidString, sessionKey: key)
+        return response
+    }
+
     private func configuredServiceURL() throws -> URL {
         let configuredBaseURL = Bundle.main.object(forInfoDictionaryKey: "OmerChat.BaseURL") as? String
         let normalizedBaseURL = (configuredBaseURL ?? Self.defaultBaseURL)
@@ -133,6 +200,45 @@ actor OmerChatService {
             return conversationID
         }
         return UUID()
+    }
+
+    private func sessionKey(for serviceURL: URL) -> String {
+        "\(serviceURL.absoluteString)|firebase-v1"
+    }
+
+    private func authenticatedGET(url: URL) async throws -> Data {
+        do {
+            return try await performAuthenticatedGET(url: url, forceTokenRefresh: false)
+        } catch OmerChatServiceError.unauthorized {
+            return try await performAuthenticatedGET(url: url, forceTokenRefresh: true)
+        }
+    }
+
+    private func performAuthenticatedGET(url: URL, forceTokenRefresh: Bool) async throws -> Data {
+        let token = try await firebaseIDToken(forceRefresh: forceTokenRefresh)
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, data: data)
+        return data
+    }
+
+    private func performLocalSync(
+        _ body: OmerLocalChatSyncRequest,
+        url: URL,
+        forceTokenRefresh: Bool
+    ) async throws -> OmerLocalChatSyncResponse {
+        let token = try await firebaseIDToken(forceRefresh: forceTokenRefresh)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(body.requestId.uuidString, forHTTPHeaderField: "Idempotency-Key")
+        request.httpBody = try encoder.encode(body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, data: data)
+        return try decoder.decode(OmerLocalChatSyncResponse.self, from: data)
     }
 
     private func performChatRequest(

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -41,6 +41,12 @@ final class OmerMobileChatModelsTests: XCTestCase {
           "conversationId": "22222222-2222-2222-2222-222222222222",
           "requestId": "11111111-1111-1111-1111-111111111111",
           "agentId": "health-assistant",
+          "billing": {
+            "plan": "pro",
+            "usedTokens": 1200,
+            "monthlyTokenLimit": 2000000,
+            "remainingTokens": 1998800
+          },
           "toolEvents": [
             {
               "type": "approval-required",
@@ -63,6 +69,8 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(response.toolEvents[0].approvalId, "approval-1")
         XCTAssertEqual(response.toolEvents[0].toolName, "logSymptoms")
         XCTAssertEqual(response.toolEvents[1].type, "result")
+        XCTAssertEqual(response.billing?.plan, "pro")
+        XCTAssertEqual(response.billing?.remainingTokens, 1_998_800)
     }
 
     func testAgentRegistryResponseDecodesRiskAndApprovalMetadata() throws {
@@ -95,5 +103,73 @@ final class OmerMobileChatModelsTests: XCTestCase {
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(json.count, 1)
         XCTAssertEqual(json["approved"] as? Bool, false)
+    }
+
+    func testCrossPlatformChatListAndDetailDecode() throws {
+        let listData = Data(#"""
+        {
+          "chats": [{
+            "id": "22222222-2222-2222-2222-222222222222",
+            "createdAt": "2026-08-11T16:00:00.000Z",
+            "title": "Symptoms after activity",
+            "userId": "99999999-9999-9999-9999-999999999999",
+            "visibility": "private"
+          }],
+          "hasMore": false
+        }
+        """#.utf8)
+        let list = try decoder.decode(OmerChatListResponse.self, from: listData)
+        XCTAssertEqual(list.chats.first?.title, "Symptoms after activity")
+        XCTAssertFalse(list.hasMore)
+
+        let detailData = Data(#"""
+        {
+          "chat": {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "createdAt": "2026-08-11T16:00:00.000Z",
+            "title": "Symptoms after activity",
+            "userId": "99999999-9999-9999-9999-999999999999",
+            "visibility": "private"
+          },
+          "messages": [{
+            "id": "33333333-3333-3333-3333-333333333333",
+            "role": "user",
+            "content": "Why do I crash after activity?",
+            "createdAt": "2026-08-11T16:01:00.000Z"
+          }]
+        }
+        """#.utf8)
+        let detail = try decoder.decode(OmerChatDetailResponse.self, from: detailData)
+        XCTAssertEqual(detail.chat.id, list.chats.first?.id)
+        XCTAssertEqual(detail.messages.first?.role, "user")
+        XCTAssertEqual(detail.messages.first?.content, "Why do I crash after activity?")
+    }
+
+    func testOnDeviceExchangeSyncContract() throws {
+        let requestID = try XCTUnwrap(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let conversationID = try XCTUnwrap(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let request = OmerLocalChatSyncRequest(
+            requestId: requestID,
+            conversationId: conversationID,
+            source: "ios-on-device",
+            messages: [
+                .init(id: UUID(), role: "user", content: "How did I sleep?"),
+                .init(id: UUID(), role: "assistant", content: "Your on-device summary shows seven hours.")
+            ]
+        )
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any])
+        XCTAssertEqual(json["source"] as? String, "ios-on-device")
+        XCTAssertEqual((json["messages"] as? [[String: Any]])?.count, 2)
+
+        let responseData = Data(#"""
+        {
+          "requestId": "11111111-1111-4111-8111-111111111111",
+          "conversationId": "22222222-2222-4222-8222-222222222222",
+          "synced": true
+        }
+        """#.utf8)
+        let response = try decoder.decode(OmerLocalChatSyncResponse.self, from: responseData)
+        XCTAssertEqual(response.conversationId, conversationID)
+        XCTAssertTrue(response.synced)
     }
 }


### PR DESCRIPTION
## Summary
- show authenticated Omer conversation history in Health Assistant
- continue an existing Home/iPhone conversation or start a new chat
- sync successful Apple on-device user/assistant exchanges to Omer
- surface Free/Pro/Max token allowance status from cloud responses

## Validation
- unsigned iOS application build passes
- iOS test target build-for-testing passes

## Dependency
Deploy together with the matching s2y-omer history, sync, and entitlement APIs.