### PR TITLE
EPIC-H01: Simplify Health Assistant experience

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -6,335 +6,68 @@
 // SPDX-License-Identifier: MIT
 //
 
-// swiftlint:disable closure_body_length sorted_imports trailing_comma
-import Security
 import SwiftUI
 
 struct HealthAssistantSettingsView: View {
     let showsDismissButton: Bool
 
     @Environment(\.dismiss) private var dismiss
-    @State private var gatewayURL: String = ""
-    @State private var modelPath: String = ""
-    @State private var bearerToken: String = ""
-    @State private var showingTokenField = false
-    @State private var showingSuccessAlert = false
-    @State private var successMessage = "Changes saved"
-    @State private var errorMessage: String?
-    @State private var hasStoredToken = false
-    @AppStorage(StorageKeys.cloudflareGatewayURL) private var storedGatewayURL = ""
-    @AppStorage(StorageKeys.cloudflareModelPath) private var storedModelPath = ""
+    @State private var showingCacheClearedAlert = false
     @AppStorage(StorageKeys.omerIncludeHealthContext) private var omerIncludeHealthContext = true
-    @AppStorage(StorageKeys.disableTimeSensitiveNotifications) private var disableTSN = false
-    @AppStorage(StorageKeys.disableScheduler) private var disableScheduler = false
-    @AppStorage(StorageKeys.disableBluetooth) private var disableBluetooth = false
-
-    // Voice & Language settings
-    @AppStorage(StorageKeys.voiceEnabled) private var voiceEnabled = true
-    @AppStorage(StorageKeys.voiceSpeakResponses) private var voiceSpeak = true
-    @AppStorage(StorageKeys.voiceInputLanguageCode) private var voiceInputLanguageCode = ""
-    @AppStorage(StorageKeys.voiceOutputLanguageCode) private var voiceOutputLanguageCode = ""
-    @AppStorage(StorageKeys.voiceSpeechRate) private var voiceSpeechRate: Double = 0.5
 
     init(showsDismissButton: Bool = false) {
         self.showsDismissButton = showsDismissButton
     }
-    
+
     var body: some View {
         Form {
             Section {
-                Text("Adjust how the assistant connects, speaks, and stores data on this device.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                LabeledContent(
+                    "On-device AI",
+                    value: AppleFoundationModelService.shared.availability.isAvailable ? "Available" : "Unavailable"
+                )
+
+                LabeledContent("AI provider", value: "Choose in chat")
+            } header: {
+                Text("AI")
+            } footer: {
+                Text("Choose On-device or Omer Online above the chat input. S2Y never changes providers without your selection.")
             }
 
             Section {
-                TextField("Gateway URL", text: $gatewayURL)
-                    .textInputAutocapitalization(.never)
-                    .keyboardType(.URL)
-                    .autocorrectionDisabled()
-
-                TextField("Model Path", text: $modelPath, axis: .vertical)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .lineLimit(2...4)
-
-                LabeledContent("Configuration Source", value: usingBundledDefaults ? "App Defaults" : "Custom on This Device")
-
-                Button("Restore Default Service Settings") {
-                    restoreDefaultServiceConfiguration()
-                }
-                .disabled(usingBundledDefaults)
+                Toggle("Share Health summary with Omer", isOn: $omerIncludeHealthContext)
             } header: {
-                Text("Cloud Service")
+                Text("Privacy")
             } footer: {
-                Text("Custom gateway values override the bundled defaults only on this device.")
+                Text("When Omer Online is selected, this allows a short summary of relevant Health data to be included with your question. On-device analysis stays on your iPhone, while chat history may still sync to your S2Y account.")
             }
 
             Section {
-                LabeledContent("AI Selection", value: "Choose in Chat")
-                LabeledContent("On-Device Status", value: AppleFoundationModelService.shared.availability.isAvailable ? "Available" : "Unavailable")
-                Toggle("Attach Health Summary", isOn: $omerIncludeHealthContext)
-            } header: {
-                Text("AI & Privacy")
-            } footer: {
-                Text("Choose On-device or Omer Online directly in the chat composer. The app does not switch providers automatically. Health summaries are attached to Omer only when this setting is enabled.")
-            }
-
-            Section {
-                Toggle("Enable Voice Features", isOn: $voiceEnabled)
-                Toggle("Speak Assistant Responses", isOn: $voiceSpeak)
-                    .disabled(!voiceEnabled)
-
-                Picker("Input Language", selection: $voiceInputLanguageCode) {
-                    ForEach(languageOptions) { option in
-                        Text(option.title).tag(option.id)
-                    }
-                }
-                .disabled(!voiceEnabled)
-
-                Picker("Response Voice", selection: $voiceOutputLanguageCode) {
-                    ForEach(languageOptions) { option in
-                        Text(option.title).tag(option.id)
-                    }
-                }
-                .disabled(!voiceEnabled)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    LabeledContent("Speech Rate", value: voiceSpeechRate.formatted(.number.precision(.fractionLength(2))))
-                        .font(.subheadline)
-                    Slider(value: $voiceSpeechRate, in: 0.2...0.7)
-                        .disabled(!voiceEnabled || !voiceSpeak)
-                }
-            } header: {
-                Text("Voice")
-            } footer: {
-                Text("Use System Default to follow the device language for speech recognition and spoken responses.")
-            }
-
-            Section {
-                LabeledContent("Bearer Token", value: hasStoredToken ? "Saved" : "Not Set")
-
-                if showingTokenField {
-                    SecureField("Bearer Token", text: $bearerToken)
-                        .textContentType(.password)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-
-                    Button("Save Token") {
-                        saveTokenToKeychain()
-                    }
-                    .disabled(bearerToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                    Button("Cancel", role: .cancel) {
-                        cancelTokenEditing()
-                    }
-                } else {
-                    Button(hasStoredToken ? "Update Token" : "Set Token") {
-                        showingTokenField = true
-                    }
-
-                    if hasStoredToken {
-                        Button("Remove Token", role: .destructive) {
-                            clearTokenFromKeychain()
-                        }
-                    }
-                }
-            } header: {
-                Text("Authentication")
-            } footer: {
-                Text("The access token is stored in Keychain and never shown in plain text after it is saved.")
-            }
-
-            Section("Data") {
-                Button("Clear Health Data Cache", role: .destructive) {
+                Button("Clear Health data cache", role: .destructive) {
                     HealthKitCache.shared.clearAll()
-                    presentSuccess("Health data cache cleared")
+                    showingCacheClearedAlert = true
                 }
-            }
-
-            #if DEBUG
-            Section {
-                Toggle("Disable Time Sensitive Notifications", isOn: $disableTSN)
-                Toggle("Disable Scheduler", isOn: $disableScheduler)
-                Toggle("Disable Bluetooth Features", isOn: $disableBluetooth)
             } header: {
-                Text("Developer Overrides")
+                Text("Data")
             } footer: {
-                Text("Keep test-only overrides away from normal preferences so the main settings flow stays focused.")
-            }
-            #endif
-
-            if let errorMessage {
-                Section {
-                    Text(errorMessage)
-                        .foregroundStyle(.red)
-                }
+                Text("This removes cached Health summaries from this iPhone. It does not delete data from Apple Health.")
             }
         }
         .navigationTitle("Health Assistant")
         .navigationBarTitleDisplayMode(.inline)
-        .scrollDismissesKeyboard(.interactively)
         .toolbar {
             if showsDismissButton {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
                         dismiss()
                     }
                 }
             }
-
-            ToolbarItem(placement: .confirmationAction) {
-                Button("Save") {
-                    saveConfiguration()
-                }
-            }
         }
-        .alert("Saved", isPresented: $showingSuccessAlert) {
+        .alert("Cache cleared", isPresented: $showingCacheClearedAlert) {
             Button("OK", role: .cancel) { }
         } message: {
-            Text(successMessage)
+            Text("Cached Health summaries were removed from this iPhone.")
         }
-        .onAppear {
-            loadConfiguration()
-        }
-    }
-
-    private struct LanguageOption: Identifiable {
-        let id: String
-        let title: String
-    }
-
-    private var languageOptions: [LanguageOption] {
-        [
-            LanguageOption(id: "", title: "System Default"),
-            LanguageOption(id: "en-US", title: "English (US)"),
-            LanguageOption(id: "zh-CN", title: "Chinese (Mandarin)"),
-            LanguageOption(id: "es-ES", title: "Español (ES)"),
-            LanguageOption(id: "fr-FR", title: "Français (FR)"),
-            LanguageOption(id: "de-DE", title: "Deutsch (DE)"),
-            LanguageOption(id: "ja-JP", title: "Japanese"),
-            LanguageOption(id: "ko-KR", title: "Korean")
-        ]
-    }
-    
-    private func loadConfiguration() {
-        gatewayURL = resolvedGatewayURL
-        modelPath = resolvedModelPath
-        hasStoredToken = loadTokenFromKeychain() != nil
-        bearerToken = ""
-        showingTokenField = false
-    }
-    
-    private func saveConfiguration() {
-        let normalizedGatewayURL = gatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedModelPath = modelPath.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !normalizedGatewayURL.isEmpty else {
-            errorMessage = "Enter a gateway URL or restore the bundled defaults."
-            return
-        }
-
-        guard URL(string: normalizedGatewayURL) != nil else {
-            errorMessage = "Enter a valid gateway URL."
-            return
-        }
-
-        storedGatewayURL = normalizedGatewayURL == bundledGatewayURL ? "" : normalizedGatewayURL
-        storedModelPath = normalizedModelPath == bundledModelPath ? "" : normalizedModelPath
-        gatewayURL = resolvedGatewayURL
-        modelPath = resolvedModelPath
-        errorMessage = nil
-        presentSuccess("Health Assistant settings saved")
-    }
-    
-    private func loadTokenFromKeychain() -> String? {
-        let keychain = Keychain()
-        return keychain.get(key: "gateway.token")
-    }
-    
-    private func saveTokenToKeychain() {
-        let query = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: "gateway.token",
-            kSecValueData as String: bearerToken.data(using: .utf8) ?? Data(),
-        ] as [String: Any]
-
-        SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
-
-        if status == errSecSuccess {
-            hasStoredToken = true
-            bearerToken = ""
-            showingTokenField = false
-            errorMessage = nil
-            presentSuccess("Access token saved to Keychain")
-        } else {
-            errorMessage = "Failed to save token."
-        }
-    }
-
-    private func cancelTokenEditing() {
-        showingTokenField = false
-        bearerToken = ""
-    }
-
-    private func clearTokenFromKeychain() {
-        let accountOnlyQuery = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: "gateway.token",
-        ] as [String: Any]
-        let serviceQuery = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "ai.cloudflare",
-            kSecAttrAccount as String: "gateway.token",
-        ] as [String: Any]
-
-        SecItemDelete(accountOnlyQuery as CFDictionary)
-        SecItemDelete(serviceQuery as CFDictionary)
-
-        hasStoredToken = false
-        bearerToken = ""
-        showingTokenField = false
-        errorMessage = nil
-        presentSuccess("Access token removed")
-    }
-
-    private func restoreDefaultServiceConfiguration() {
-        storedGatewayURL = ""
-        storedModelPath = ""
-        gatewayURL = bundledGatewayURL
-        modelPath = bundledModelPath
-        errorMessage = nil
-    }
-
-    private func presentSuccess(_ message: String) {
-        successMessage = message
-        showingSuccessAlert = true
-    }
-
-    private var bundledGatewayURL: String {
-        (Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.GatewayURL") as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    }
-
-    private var bundledModelPath: String {
-        (Bundle.main.object(forInfoDictionaryKey: "CFWorkersAI.ModelPath") as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    }
-
-    private var resolvedGatewayURL: String {
-        let override = storedGatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        return override.isEmpty ? bundledGatewayURL : override
-    }
-
-    private var resolvedModelPath: String {
-        let override = storedModelPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        return override.isEmpty ? bundledModelPath : override
-    }
-
-    private var usingBundledDefaults: Bool {
-        storedGatewayURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && storedModelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }

--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -72,16 +72,13 @@ struct HealthAssistantSettingsView: View {
             }
 
             Section {
-                LabeledContent("Primary AI", value: "Apple On-Device")
-                LabeledContent(
-                    "Current Route",
-                    value: AppleFoundationModelService.shared.availability.isAvailable ? "On-Device" : "Omer Fallback"
-                )
+                LabeledContent("AI Selection", value: "Choose in Chat")
+                LabeledContent("On-Device Status", value: AppleFoundationModelService.shared.availability.isAvailable ? "Available" : "Unavailable")
                 Toggle("Attach Health Summary", isOn: $omerIncludeHealthContext)
             } header: {
                 Text("AI & Privacy")
             } footer: {
-                Text("The assistant uses Apple Intelligence on this device whenever available, then falls back to Omer automatically. Health summaries are attached only when this setting is enabled.")
+                Text("Choose On-device or Omer Online directly in the chat composer. The app does not switch providers automatically. Health summaries are attached to Omer only when this setting is enabled.")
             }
 
             Section {

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -74,6 +74,7 @@ private enum AssistantAIMode: String, CaseIterable, Identifiable {
 
 struct HealthAssistantView: View {
     @Environment(\.homeDrawerProgress) private var homeDrawerProgress
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Binding private var requestedConversationID: UUID?
 
     @State private var inputText: String = ""
@@ -81,10 +82,6 @@ struct HealthAssistantView: View {
     @State private var isProcessing = false
     @State private var notice: AssistantNotice?
     @State private var showingSettings = false
-    @State private var showingHistory = false
-    @State private var chatHistory: [OmerChatSummary] = []
-    @State private var isLoadingHistory = false
-    @State private var historyError: String?
     @State private var streamTick = 0
     @State private var pendingToolApproval: OmerToolApprovalPayload?
     @FocusState private var isInputFocused: Bool
@@ -125,14 +122,7 @@ struct HealthAssistantView: View {
             .navigationTitle("Health Assistant")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button {
-                        showingHistory = true
-                    } label: {
-                        Image(systemName: "clock.arrow.circlepath")
-                            .accessibilityLabel("Conversation History")
-                    }
-
+                ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         showingSettings = true
                     } label: {
@@ -151,12 +141,6 @@ struct HealthAssistantView: View {
                 NavigationStack {
                     HealthAssistantSettingsView(showsDismissButton: true)
                 }
-            }
-            .sheet(isPresented: $showingHistory) {
-                conversationHistorySheet
-                    .task {
-                        await loadConversationHistory()
-                    }
             }
         }
         .task {
@@ -184,102 +168,21 @@ struct HealthAssistantView: View {
         }
     }
 
-    private var conversationHistorySheet: some View {
-        NavigationStack {
-            Group {
-                if isLoadingHistory && chatHistory.isEmpty {
-                    ProgressView("Loading conversations…")
-                } else if let historyError, chatHistory.isEmpty {
-                    ContentUnavailableView(
-                        "History Unavailable",
-                        systemImage: "exclamationmark.bubble",
-                        description: Text(historyError)
-                    )
-                } else if chatHistory.isEmpty {
-                    ContentUnavailableView(
-                        "No Conversations Yet",
-                        systemImage: "bubble.left.and.bubble.right",
-                        description: Text("Chats from S2Y Home and this iPhone will appear here.")
-                    )
-                } else {
-                    List(chatHistory) { chat in
-                        Button {
-                            Task { await openConversation(chat) }
-                        } label: {
-                            VStack(alignment: .leading, spacing: 5) {
-                                Text(chat.title)
-                                    .font(.headline)
-                                    .foregroundStyle(.primary)
-                                    .lineLimit(2)
-                                Text("Synced with S2Y")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.vertical, 4)
-                        }
-                    }
-                    .refreshable {
-                        await loadConversationHistory()
-                    }
-                }
-            }
-            .navigationTitle("Conversations")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { showingHistory = false }
-                }
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        Task { await beginNewConversation() }
-                    } label: {
-                        Label("New Chat", systemImage: "square.and.pencil")
-                    }
-                }
-            }
-        }
-    }
-
-    @MainActor
-    private func loadConversationHistory() async {
-        isLoadingHistory = true
-        historyError = nil
-        defer { isLoadingHistory = false }
-        chatHistory = await omerChatService.cachedChats()
-        do {
-            chatHistory = try await omerChatService.fetchChats().chats
-        } catch {
-            if chatHistory.isEmpty {
-                historyError = error.localizedDescription
-            }
-        }
-    }
-
-    @MainActor
-    private func openConversation(_ chat: OmerChatSummary) async {
-        await openConversation(id: chat.id)
-    }
-
     @MainActor
     private func openConversation(id: UUID) async {
-        isLoadingHistory = true
-        historyError = nil
         do {
             let detail = try await omerChatService.fetchChat(id: id)
             try await omerChatService.selectChat(id: id)
             displayConversation(detail)
-            showingHistory = false
         } catch {
             if let cached = await omerChatService.cachedChat(id: id) {
                 try? await omerChatService.selectChat(id: id)
                 displayConversation(cached)
-                showingHistory = false
                 notice = AssistantNotice(message: "Showing the locally saved copy of this chat.", tone: .info)
             } else {
-                historyError = error.localizedDescription
+                notice = AssistantNotice(message: "This conversation could not be opened. Try again when you're online.", tone: .warning)
             }
         }
-        isLoadingHistory = false
     }
 
     @MainActor
@@ -300,10 +203,9 @@ struct HealthAssistantView: View {
             try await omerChatService.startNewChat()
             messages = []
             notice = nil
-            showingHistory = false
             onHistoryChanged()
         } catch {
-            historyError = error.localizedDescription
+            notice = AssistantNotice(message: "A new conversation could not be started. Please try again.", tone: .warning)
         }
     }
 
@@ -326,13 +228,16 @@ struct HealthAssistantView: View {
             }
 
             VStack(alignment: .leading, spacing: 10) {
-                Text("Suggested Questions")
+                Text("Try asking")
                     .font(.headline)
                     .padding(.horizontal, 4)
 
-                ForEach(quickQuerySuggestions) { suggestion in
-                    QuickQueryRow(suggestion: suggestion) {
-                        inputText = suggestion.query
+                LazyVGrid(columns: suggestionColumns, spacing: 10) {
+                    ForEach(quickQuerySuggestions) { suggestion in
+                        QuickQueryRow(suggestion: suggestion) {
+                            inputText = suggestion.query
+                            isInputFocused = true
+                        }
                     }
                 }
             }
@@ -476,10 +381,6 @@ struct HealthAssistantView: View {
     
     private func initializeHealthKit() async {
         if isRunningInSimulator {
-            notice = AssistantNotice(
-                message: "Simulator preview: use a physical iPhone for live Health data.",
-                tone: .info
-            )
             return
         }
 
@@ -614,11 +515,8 @@ struct HealthAssistantView: View {
             pendingToolApproval = approval
         case .toolResult(let toolName):
             appendAssistantDelta(id: assistantMessageID, delta: "\n\n✓ \(toolName) completed.")
-        case .billing(let billing):
-            notice = AssistantNotice(
-                message: "\(billing.plan.capitalized) plan · \(billing.remainingTokens.formatted()) AI tokens remaining this month.",
-                tone: .info
-            )
+        case .billing:
+            break
         case .error(let message):
             updateAssistantMessage(id: assistantMessageID, content: message)
         }
@@ -666,62 +564,24 @@ struct HealthAssistantView: View {
     }
 
     private var welcomeHero: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 14) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .fill(Color.red.opacity(0.12))
-                        .frame(width: 54, height: 54)
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "heart.text.square.fill")
+                .font(.title2)
+                .foregroundStyle(.red)
+                .frame(width: 44, height: 44)
+                .background(Color.red.opacity(0.1), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .accessibilityLabel("Health Assistant Icon")
 
-                    Image(systemName: "heart.text.square.fill")
-                        .font(.title3)
-                        .foregroundColor(.red)
-                        .accessibilityLabel("Health Assistant Icon")
-                }
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Ask about your health")
+                    .font(.title3.weight(.semibold))
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Ask about your health in plain language")
-                        .font(.title3.weight(.semibold))
-
-                    Text("Explore steps, heart rate, sleep, and activity trends without digging through charts first.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            HStack(spacing: 10) {
-                statusChip(
-                    title: selectedAIMode.title,
-                    systemImage: selectedAIMode.systemImage,
-                    tint: selectedAIMode == .onDevice ? .green : .blue
-                )
-
-                statusChip(
-                    title: isRunningInSimulator ? "Simulator Preview" : (HKHealthStore.isHealthDataAvailable() ? "HealthKit Ready" : "Unavailable"),
-                    systemImage: isRunningInSimulator ? "iphone" : (HKHealthStore.isHealthDataAvailable() ? "heart.circle" : "exclamationmark.circle"),
-                    tint: isRunningInSimulator ? .orange : (HKHealthStore.isHealthDataAvailable() ? .pink : .orange)
-                )
+                Text("Get a clear summary of your sleep, activity, heart rate, and other Health data.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             }
         }
-        .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(Color(uiColor: .secondarySystemGroupedBackground))
-        )
-    }
-
-    private func statusChip(title: String, systemImage: String, tint: Color) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: systemImage)
-            Text(title)
-                .fontWeight(.semibold)
-        }
-        .font(.subheadline)
-        .foregroundStyle(tint)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(tint.opacity(0.12))
-        .clipShape(Capsule())
+        .padding(.vertical, 6)
     }
 
     private var quickQuerySuggestions: [QuickQuerySuggestion] {
@@ -729,28 +589,31 @@ struct HealthAssistantView: View {
             QuickQuerySuggestion(
                 icon: "figure.walk",
                 title: "Step Trends",
-                subtitle: "7-day movement snapshot",
                 query: "How have my step counts trended over the past 7 days?"
             ),
             QuickQuerySuggestion(
                 icon: "heart.fill",
-                title: "Heart Rate Comparison",
-                subtitle: "This week versus last week",
+                title: "Heart Rate",
                 query: "Compare my average heart rate this week versus last week."
             ),
             QuickQuerySuggestion(
                 icon: "bed.double.fill",
-                title: "Sleep Analysis",
-                subtitle: "Recent rest and recovery",
+                title: "Sleep Quality",
                 query: "How has my sleep quality been recently?"
             ),
             QuickQuerySuggestion(
                 icon: "flame.fill",
                 title: "Active Energy",
-                subtitle: "30-day activity change",
                 query: "How has my active energy changed over the past 30 days?"
             )
         ]
+    }
+
+    private var suggestionColumns: [GridItem] {
+        if dynamicTypeSize.isAccessibilitySize {
+            return [GridItem(.flexible())]
+        }
+        return [GridItem(.flexible()), GridItem(.flexible())]
     }
 
     private var selectedAIMode: AssistantAIMode {
@@ -878,7 +741,6 @@ private struct QuickQuerySuggestion: Identifiable {
     let id = UUID()
     let icon: String
     let title: String
-    let subtitle: String
     let query: String
 }
 
@@ -888,43 +750,22 @@ private struct QuickQueryRow: View {
     
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 14) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .fill(Color.blue.opacity(0.12))
-                        .frame(width: 48, height: 48)
-
-                    Image(systemName: suggestion.icon)
-                        .font(.title3)
-                        .foregroundColor(.blue)
-                        .accessibilityLabel(suggestion.title)
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(suggestion.title)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-
-                    Text(suggestion.subtitle)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-
-                    Text(suggestion.query)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(2)
-                }
-
-                Spacer(minLength: 12)
-
-                Image(systemName: "arrow.up.left.circle.fill")
+            VStack(alignment: .leading, spacing: 12) {
+                Image(systemName: suggestion.icon)
                     .font(.title3)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.blue)
+                    .accessibilityHidden(true)
+
+                Text(suggestion.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 78, alignment: .leading)
+            .padding(14)
             .background(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
                     .fill(Color(uiColor: .secondarySystemGroupedBackground))
             )
         }

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -754,6 +754,105 @@ enum ChatMarkdownRenderer {
             )
         )
     }
+
+    static func blocks(from source: String) -> [ChatMarkdownBlock] {
+        var blocks: [ChatMarkdownBlock] = []
+        var paragraphLines: [String] = []
+        var codeLines: [String] = []
+        var isInsideCodeBlock = false
+
+        func appendParagraph() {
+            guard !paragraphLines.isEmpty else { return }
+            let paragraph = paragraphLines.joined(separator: "\n")
+            blocks.append(ChatMarkdownBlock(kind: .paragraph, content: inline(paragraph)))
+            paragraphLines.removeAll()
+        }
+
+        for line in source.components(separatedBy: .newlines) {
+            if line.hasPrefix("```") {
+                if isInsideCodeBlock {
+                    blocks.append(ChatMarkdownBlock(kind: .code, content: AttributedString(codeLines.joined(separator: "\n"))))
+                    codeLines.removeAll()
+                } else {
+                    appendParagraph()
+                }
+                isInsideCodeBlock.toggle()
+                continue
+            }
+
+            if isInsideCodeBlock {
+                codeLines.append(line)
+                continue
+            }
+
+            if line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                appendParagraph()
+                continue
+            }
+
+            if let heading = heading(from: line) {
+                appendParagraph()
+                blocks.append(ChatMarkdownBlock(kind: .heading(heading.level), content: inline(heading.text)))
+            } else if let item = unorderedListItem(from: line) {
+                appendParagraph()
+                blocks.append(ChatMarkdownBlock(kind: .unorderedListItem, content: inline(item)))
+            } else if let item = orderedListItem(from: line) {
+                appendParagraph()
+                blocks.append(ChatMarkdownBlock(kind: .orderedListItem(item.number), content: inline(item.text)))
+            } else if line.hasPrefix("> ") {
+                appendParagraph()
+                blocks.append(ChatMarkdownBlock(kind: .quote, content: inline(String(line.dropFirst(2)))))
+            } else {
+                paragraphLines.append(line)
+            }
+        }
+
+        appendParagraph()
+        if !codeLines.isEmpty {
+            blocks.append(ChatMarkdownBlock(kind: .code, content: AttributedString(codeLines.joined(separator: "\n"))))
+        }
+        return blocks
+    }
+
+    private static func inline(_ source: String) -> AttributedString {
+        attributedString(from: source) ?? AttributedString(source)
+    }
+
+    private static func heading(from line: String) -> (level: Int, text: String)? {
+        let level = line.prefix(while: { $0 == "#" }).count
+        guard (1...6).contains(level), line.dropFirst(level).hasPrefix(" ") else { return nil }
+        return (level, String(line.dropFirst(level + 1)))
+    }
+
+    private static func unorderedListItem(from line: String) -> String? {
+        guard line.count > 2 else { return nil }
+        let marker = line.prefix(2)
+        guard marker == "- " || marker == "* " || marker == "+ " else { return nil }
+        return String(line.dropFirst(2))
+    }
+
+    private static func orderedListItem(from line: String) -> (number: Int, text: String)? {
+        guard let separator = line.firstIndex(of: "."), separator < line.endIndex else { return nil }
+        let numberText = line[..<separator]
+        let contentStart = line.index(after: separator)
+        guard let number = Int(numberText), contentStart < line.endIndex, line[contentStart] == " " else { return nil }
+        return (number, String(line[line.index(after: contentStart)...]))
+    }
+}
+
+struct ChatMarkdownBlock: Identifiable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case heading(Int)
+        case unorderedListItem
+        case orderedListItem(Int)
+        case quote
+        case code
+        case paragraph
+    }
+
+    let id = UUID()
+    let kind: Kind
+    let content: AttributedString
 }
 
 struct MessageBubble: View {
@@ -789,12 +888,55 @@ struct MessageBubble: View {
 
     @ViewBuilder
     private var messageContent: some View {
-        if message.role == .assistant,
-           let attributed = ChatMarkdownRenderer.attributedString(from: message.content) {
-            Text(attributed)
-                .textSelection(.enabled)
+        if message.role == .assistant {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(ChatMarkdownRenderer.blocks(from: message.content)) { block in
+                    markdownBlock(block)
+                }
+            }
+            .textSelection(.enabled)
         } else {
             Text(message.content)
+        }
+    }
+
+    @ViewBuilder
+    private func markdownBlock(_ block: ChatMarkdownBlock) -> some View {
+        switch block.kind {
+        case .heading(let level):
+            Text(block.content)
+                .font(level <= 2 ? .headline : .subheadline.weight(.semibold))
+                .accessibilityAddTraits(.isHeader)
+        case .unorderedListItem:
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("•")
+                    .accessibilityHidden(true)
+                Text(block.content)
+            }
+        case .orderedListItem(let number):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("\(number).")
+                    .accessibilityHidden(true)
+                Text(block.content)
+            }
+        case .quote:
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.secondary.opacity(0.5))
+                    .frame(width: 3)
+                    .accessibilityHidden(true)
+                Text(block.content)
+                    .foregroundStyle(.secondary)
+            }
+        case .code:
+            ScrollView(.horizontal) {
+                Text(block.content)
+                    .font(.system(.footnote, design: .monospaced))
+                    .padding(8)
+            }
+            .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+        case .paragraph:
+            Text(block.content)
         }
     }
 }

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -84,6 +84,8 @@ struct HealthAssistantView: View {
     @State private var showingSettings = false
     @State private var streamTick = 0
     @State private var pendingToolApproval: OmerToolApprovalPayload?
+    @State private var availableSuggestionMetrics: Set<HealthKitService.MetricKind> = []
+    @State private var didLoadSuggestionAvailability = false
     @FocusState private var isInputFocused: Bool
     @AppStorage(StorageKeys.omerIncludeHealthContext) private var omerIncludeHealthContext = true
     @AppStorage(StorageKeys.healthAssistantAIMode) private var aiModeRawValue = AssistantAIMode.onDevice.rawValue
@@ -240,6 +242,19 @@ struct HealthAssistantView: View {
                         }
                     }
                 }
+
+                if didLoadSuggestionAvailability, quickQuerySuggestions.isEmpty {
+                    ContentUnavailableView(
+                        "No recent Health data",
+                        systemImage: "heart.text.clipboard",
+                        description: Text("Connect Health data to see questions tailored to the information available on this iPhone.")
+                    )
+                    .frame(maxWidth: .infinity)
+                } else if !didLoadSuggestionAvailability {
+                    ProgressView("Checking available Health data…")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 20)
+                }
             }
 
             Spacer(minLength: 24)
@@ -381,6 +396,7 @@ struct HealthAssistantView: View {
     
     private func initializeHealthKit() async {
         if isRunningInSimulator {
+            didLoadSuggestionAvailability = true
             return
         }
 
@@ -394,12 +410,34 @@ struct HealthAssistantView: View {
 
         do {
             try await healthService.requestAuthorization()
+            await loadQuickQueryAvailability()
         } catch {
+            didLoadSuggestionAvailability = true
             notice = AssistantNotice(
                 message: "HealthKit authorization failed: \(error.localizedDescription)",
                 tone: .warning
             )
         }
+    }
+
+    private func loadQuickQueryAvailability() async {
+        let end = Date()
+        let start = Calendar.current.date(byAdding: .day, value: -30, to: end) ?? end
+        var available: Set<HealthKitService.MetricKind> = []
+
+        for suggestion in HealthQuickQuerySuggestion.catalog {
+            guard !available.contains(suggestion.metricKind) else { continue }
+            if let metrics = try? await healthService.fetchDailyMetrics(
+                kind: suggestion.metricKind,
+                start: start,
+                end: end
+            ), metrics.contains(where: { $0.value > 0 }) {
+                available.insert(suggestion.metricKind)
+            }
+        }
+
+        availableSuggestionMetrics = available
+        didLoadSuggestionAvailability = true
     }
     
     private func sendMessage() async {
@@ -584,43 +622,67 @@ struct HealthAssistantView: View {
         .padding(.vertical, 6)
     }
 
-    private var quickQuerySuggestions: [QuickQuerySuggestion] {
-        [
-            QuickQuerySuggestion(
+    private var quickQuerySuggestions: [HealthQuickQuerySuggestion] {
+        HealthQuickQuerySuggestion.catalog.filter { availableSuggestionMetrics.contains($0.metricKind) }
+    }
+}
+
+struct HealthQuickQuerySuggestion: Identifiable, Equatable, Sendable {
+    let id: String
+    let metricKind: HealthKitService.MetricKind
+    let icon: String
+    let title: String
+    let query: String
+
+    static let catalog: [HealthQuickQuerySuggestion] = [
+            HealthQuickQuerySuggestion(
+                id: "steps",
+                metricKind: .steps,
                 icon: "figure.walk",
                 title: "Step Trends",
                 query: "How have my step counts trended over the past 7 days?"
             ),
-            QuickQuerySuggestion(
+            HealthQuickQuerySuggestion(
+                id: "heart-rate",
+                metricKind: .heartRateAverage,
                 icon: "heart.fill",
                 title: "Heart Rate",
                 query: "Compare my average heart rate this week versus last week."
             ),
-            QuickQuerySuggestion(
+            HealthQuickQuerySuggestion(
+                id: "sleep",
+                metricKind: .sleepDurationHours,
                 icon: "bed.double.fill",
                 title: "Sleep Quality",
                 query: "How has my sleep quality been recently?"
             ),
-            QuickQuerySuggestion(
+            HealthQuickQuerySuggestion(
+                id: "active-energy",
+                metricKind: .activeEnergy,
                 icon: "flame.fill",
                 title: "Active Energy",
                 query: "How has my active energy changed over the past 30 days?"
             )
         ]
-    }
 
-    private var suggestionColumns: [GridItem] {
+    static func available(for metrics: Set<HealthKitService.MetricKind>) -> [HealthQuickQuerySuggestion] {
+        catalog.filter { metrics.contains($0.metricKind) }
+    }
+}
+
+private extension HealthAssistantView {
+    var suggestionColumns: [GridItem] {
         if dynamicTypeSize.isAccessibilitySize {
             return [GridItem(.flexible())]
         }
         return [GridItem(.flexible()), GridItem(.flexible())]
     }
 
-    private var selectedAIMode: AssistantAIMode {
+    var selectedAIMode: AssistantAIMode {
         AssistantAIMode(rawValue: aiModeRawValue) ?? .onDevice
     }
 
-    private var aiModeBinding: Binding<AssistantAIMode> {
+    var aiModeBinding: Binding<AssistantAIMode> {
         Binding(
             get: { selectedAIMode },
             set: { aiModeRawValue = $0.rawValue }
@@ -737,15 +799,8 @@ struct MessageBubble: View {
     }
 }
 
-private struct QuickQuerySuggestion: Identifiable {
-    let id = UUID()
-    let icon: String
-    let title: String
-    let query: String
-}
-
 private struct QuickQueryRow: View {
-    let suggestion: QuickQuerySuggestion
+    let suggestion: HealthQuickQuerySuggestion
     let action: () -> Void
     
     var body: some View {

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -51,8 +51,30 @@ enum HealthAssistantError: Error, LocalizedError {
     }
 }
 
+private enum AssistantAIMode: String, CaseIterable, Identifiable {
+    case onDevice
+    case omer
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .onDevice: "On-device"
+        case .omer: "Omer Online"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .onDevice: "apple.intelligence"
+        case .omer: "icloud"
+        }
+    }
+}
+
 struct HealthAssistantView: View {
     @Environment(\.homeDrawerProgress) private var homeDrawerProgress
+    @Binding private var requestedConversationID: UUID?
 
     @State private var inputText: String = ""
     @State private var messages: [ChatMessage] = []
@@ -65,13 +87,28 @@ struct HealthAssistantView: View {
     @State private var historyError: String?
     @State private var streamTick = 0
     @State private var pendingToolApproval: OmerToolApprovalPayload?
+    @FocusState private var isInputFocused: Bool
     @AppStorage(StorageKeys.omerIncludeHealthContext) private var omerIncludeHealthContext = true
+    @AppStorage(StorageKeys.healthAssistantAIMode) private var aiModeRawValue = AssistantAIMode.onDevice.rawValue
+
+    private let newChatRequestID: UUID
+    private let onHistoryChanged: () -> Void
     
     private let healthService = HealthKitService.shared
     private let appleModelService = AppleFoundationModelService.shared
     private let omerChatService = OmerChatService.shared
     private let logger = Logger(subsystem: "com.s2y.app", category: "HealthAssistantView")
     private let isRunningInSimulator = ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil
+
+    init(
+        requestedConversationID: Binding<UUID?> = .constant(nil),
+        newChatRequestID: UUID = UUID(),
+        onHistoryChanged: @escaping () -> Void = {}
+    ) {
+        self._requestedConversationID = requestedConversationID
+        self.newChatRequestID = newChatRequestID
+        self.onHistoryChanged = onHistoryChanged
+    }
     
     var body: some View {
         NavigationStack {
@@ -103,6 +140,12 @@ struct HealthAssistantView: View {
                             .accessibilityLabel("Settings")
                     }
                 }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        isInputFocused = false
+                    }
+                }
             }
             .sheet(isPresented: $showingSettings) {
                 NavigationStack {
@@ -118,6 +161,14 @@ struct HealthAssistantView: View {
         }
         .task {
             await initializeHealthKit()
+        }
+        .task(id: requestedConversationID) {
+            guard let requestedConversationID else { return }
+            await openConversation(id: requestedConversationID)
+            self.requestedConversationID = nil
+        }
+        .onChange(of: newChatRequestID) {
+            Task { await beginNewConversation() }
         }
         .alert(item: $pendingToolApproval) { approval in
             Alert(
@@ -194,33 +245,53 @@ struct HealthAssistantView: View {
         isLoadingHistory = true
         historyError = nil
         defer { isLoadingHistory = false }
+        chatHistory = await omerChatService.cachedChats()
         do {
             chatHistory = try await omerChatService.fetchChats().chats
         } catch {
-            historyError = error.localizedDescription
+            if chatHistory.isEmpty {
+                historyError = error.localizedDescription
+            }
         }
     }
 
     @MainActor
     private func openConversation(_ chat: OmerChatSummary) async {
+        await openConversation(id: chat.id)
+    }
+
+    @MainActor
+    private func openConversation(id: UUID) async {
         isLoadingHistory = true
         historyError = nil
         do {
-            let detail = try await omerChatService.fetchChat(id: chat.id)
-            try await omerChatService.selectChat(id: chat.id)
-            messages = detail.messages.compactMap { message in
-                guard !message.content.isEmpty else { return nil }
-                return ChatMessage(
-                    id: message.id,
-                    role: message.role == "user" ? .user : .assistant,
-                    content: message.content
-                )
-            }
+            let detail = try await omerChatService.fetchChat(id: id)
+            try await omerChatService.selectChat(id: id)
+            displayConversation(detail)
             showingHistory = false
         } catch {
-            historyError = error.localizedDescription
+            if let cached = await omerChatService.cachedChat(id: id) {
+                try? await omerChatService.selectChat(id: id)
+                displayConversation(cached)
+                showingHistory = false
+                notice = AssistantNotice(message: "Showing the locally saved copy of this chat.", tone: .info)
+            } else {
+                historyError = error.localizedDescription
+            }
         }
         isLoadingHistory = false
+    }
+
+    @MainActor
+    private func displayConversation(_ detail: OmerChatDetailResponse) {
+        messages = detail.messages.compactMap { message in
+            guard !message.content.isEmpty else { return nil }
+            return ChatMessage(
+                id: message.id,
+                role: message.role == "user" ? .user : .assistant,
+                content: message.content
+            )
+        }
     }
 
     @MainActor
@@ -230,6 +301,7 @@ struct HealthAssistantView: View {
             messages = []
             notice = nil
             showingHistory = false
+            onHistoryChanged()
         } catch {
             historyError = error.localizedDescription
         }
@@ -238,6 +310,10 @@ struct HealthAssistantView: View {
     private var welcomeView: some View {
         ScrollView {
             welcomeContent
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .onTapGesture {
+            isInputFocused = false
         }
     }
 
@@ -294,6 +370,10 @@ struct HealthAssistantView: View {
                 }
                 .padding()
             }
+            .scrollDismissesKeyboard(.interactively)
+            .onTapGesture {
+                isInputFocused = false
+            }
             .onChange(of: messages.count) {
                 if let lastMessage = messages.last {
                     withAnimation(.easeInOut(duration: 0.3)) {
@@ -316,13 +396,23 @@ struct HealthAssistantView: View {
             Divider()
             
             HStack {
-                Label(
-                    appleModelService.availability.isAvailable ? "On-device Apple AI" : "Omer fallback",
-                    systemImage: appleModelService.availability.isAvailable ? "apple.intelligence" : "icloud"
-                )
-                .font(.caption)
-                .foregroundColor(.secondary)
+                Menu {
+                    Picker("AI provider", selection: aiModeBinding) {
+                        ForEach(AssistantAIMode.allCases) { mode in
+                            Label(mode.title, systemImage: mode.systemImage)
+                                .tag(mode)
+                        }
+                    }
+                } label: {
+                    Label(selectedAIMode.title, systemImage: selectedAIMode.systemImage)
+                        .font(.caption.weight(.semibold))
+                }
+                .accessibilityLabel("AI provider")
+                .accessibilityIdentifier("health-assistant-ai-mode")
                 Spacer()
+                Text(selectedAIMode == .onDevice ? "Runs on this iPhone" : "Uses Omer online")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
             .padding(.horizontal)
             .padding(.top, 6)
@@ -332,6 +422,12 @@ struct HealthAssistantView: View {
                     .textFieldStyle(.roundedBorder)
                     .lineLimit(1...4)
                     .disabled(isProcessing)
+                    .focused($isInputFocused)
+                    .submitLabel(.send)
+                    .onSubmit {
+                        guard !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, !isProcessing else { return }
+                        Task { await sendMessage() }
+                    }
                     .accessibilityIdentifier("health-assistant-input")
                 
                 Button {
@@ -416,6 +512,7 @@ struct HealthAssistantView: View {
         
         let query = trimmedInput
         inputText = ""
+        isInputFocused = false
         isProcessing = true
         notice = nil
 
@@ -427,7 +524,7 @@ struct HealthAssistantView: View {
             includeHealthContext: omerIncludeHealthContext
         )
 
-        if appleModelService.availability.isAvailable {
+        if selectedAIMode == .onDevice, appleModelService.availability.isAvailable {
             do {
                 try await appleModelService.streamResponse(
                     to: query,
@@ -452,24 +549,33 @@ struct HealthAssistantView: View {
                         )
                     }
                 }
+                onHistoryChanged()
                 isProcessing = false
                 return
             } catch {
                 logger.error("Apple on-device generation failed: \(error.localizedDescription)")
-                updateAssistantMessage(id: assistantPlaceholder.id, content: "")
-                notice = AssistantNotice(
-                    message: "On-device AI could not finish this response. Using Omer instead.",
-                    tone: .warning
+                updateAssistantMessage(
+                    id: assistantPlaceholder.id,
+                    content: "On-device Apple AI could not finish this response: \(error.localizedDescription)"
                 )
+                isProcessing = false
+                return
             }
-        } else {
+        } else if selectedAIMode == .onDevice {
             notice = AssistantNotice(
-                message: appleModelService.availability.fallbackExplanation,
-                tone: .info
+                message: appleModelService.availability.fallbackExplanation.replacingOccurrences(of: "Using Omer instead.", with: "Choose Omer Online to continue."),
+                tone: .warning
             )
+            updateAssistantMessage(
+                id: assistantPlaceholder.id,
+                content: "On-device Apple AI is not available. Choose Omer Online from the provider menu to send this request online."
+            )
+            isProcessing = false
+            return
         }
 
         await sendWithOmer(query, assistantMessageID: assistantPlaceholder.id)
+        onHistoryChanged()
         isProcessing = false
     }
 
@@ -585,9 +691,9 @@ struct HealthAssistantView: View {
 
             HStack(spacing: 10) {
                 statusChip(
-                    title: appleModelService.availability.isAvailable ? "On-device AI" : "Omer fallback",
-                    systemImage: appleModelService.availability.isAvailable ? "apple.intelligence" : "icloud",
-                    tint: appleModelService.availability.isAvailable ? .green : .blue
+                    title: selectedAIMode.title,
+                    systemImage: selectedAIMode.systemImage,
+                    tint: selectedAIMode == .onDevice ? .green : .blue
                 )
 
                 statusChip(
@@ -646,6 +752,17 @@ struct HealthAssistantView: View {
             )
         ]
     }
+
+    private var selectedAIMode: AssistantAIMode {
+        AssistantAIMode(rawValue: aiModeRawValue) ?? .onDevice
+    }
+
+    private var aiModeBinding: Binding<AssistantAIMode> {
+        Binding(
+            get: { selectedAIMode },
+            set: { aiModeRawValue = $0.rawValue }
+        )
+    }
 }
 
 private struct AssistantNotice {
@@ -702,6 +819,18 @@ struct ChatMessage: Identifiable, Sendable {
     }
 }
 
+enum ChatMarkdownRenderer {
+    static func attributedString(from source: String) -> AttributedString? {
+        try? AttributedString(
+            markdown: source,
+            options: .init(
+                interpretedSyntax: .full,
+                failurePolicy: .returnPartiallyParsedIfPossible
+            )
+        )
+    }
+}
+
 struct MessageBubble: View {
     let message: ChatMessage
     
@@ -712,7 +841,7 @@ struct MessageBubble: View {
             }
             
             VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 4) {
-                Text(message.content)
+                messageContent
                     .accessibilityIdentifier(
                         message.role == .assistant
                             ? "health-assistant-response"
@@ -730,6 +859,17 @@ struct MessageBubble: View {
             if message.role == .assistant {
                 Spacer(minLength: 60)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var messageContent: some View {
+        if message.role == .assistant,
+           let attributed = ChatMarkdownRenderer.attributedString(from: message.content) {
+            Text(attributed)
+                .textSelection(.enabled)
+        } else {
+            Text(message.content)
         }
     }
 }

--- a/S2Y/HealthKit/HealthKitService.swift
+++ b/S2Y/HealthKit/HealthKitService.swift
@@ -86,7 +86,7 @@ public final class HealthKitService {
         public let value: Double
     }
 
-    public enum MetricKind: Sendable, Codable, CaseIterable {
+    public enum MetricKind: Sendable, Codable, CaseIterable, Hashable {
         case steps
         case heartRateAverage
         case restingHeartRate

--- a/S2Y/HomeView.swift
+++ b/S2Y/HomeView.swift
@@ -75,6 +75,10 @@ struct HomeView: View {
 
     @State private var presentingAccount = false
     @State private var isDrawerOpen = false
+    @State private var drawerChatHistory: [OmerChatSummary] = []
+    @State private var requestedConversationID: UUID?
+    @State private var newChatRequestID = UUID()
+    @State private var isRefreshingChatHistory = false
 
 
     var body: some View {
@@ -97,13 +101,26 @@ struct HomeView: View {
         .accountRequired(!FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding) {
             AccountSheet()
         }
+        .task {
+            await loadDrawerChatHistory()
+        }
+        .onChange(of: isDrawerOpen) {
+            guard isDrawerOpen else { return }
+            Task { await loadDrawerChatHistory() }
+        }
     }
 
     @ViewBuilder
     private var selectedContent: some View {
         switch selectedTab {
         case .healthAssistant:
-            HealthAssistantView()
+            HealthAssistantView(
+                requestedConversationID: $requestedConversationID,
+                newChatRequestID: newChatRequestID,
+                onHistoryChanged: {
+                    Task { await loadDrawerChatHistory() }
+                }
+            )
         case .schedule:
             ScheduleView(presentingAccount: $presentingAccount)
         case .contact:
@@ -143,23 +160,46 @@ struct HomeView: View {
         VStack(alignment: .leading, spacing: 0) {
             drawerHeader
 
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Navigate")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                    .padding(.horizontal, 24)
-                    .padding(.bottom, 6)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    newChatButton
 
-                ForEach(Tabs.allCases, id: \.self) { tab in
-                    drawerRow(for: tab)
+                    Text("Recent chats")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 24)
+                        .padding(.top, 12)
+
+                    if drawerChatHistory.isEmpty {
+                        Text(isRefreshingChatHistory ? "Loading conversations…" : "Your Omer and on-device chats will appear here.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 8)
+                    } else {
+                        ForEach(drawerChatHistory.prefix(20)) { chat in
+                            drawerChatRow(chat)
+                        }
+                    }
+
+                    Divider()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 8)
+
+                    Text("Navigate")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 24)
+
+                    ForEach(Tabs.allCases, id: \.self) { tab in
+                        drawerRow(for: tab)
+                    }
                 }
+                .padding(.top, 10)
+                .padding(.bottom, 18)
             }
-            .padding(.top, 10)
-
-            Spacer(minLength: 20)
-
-            drawerFooter
         }
         .frame(width: width, alignment: .leading)
         .padding(.top, 20)
@@ -204,47 +244,51 @@ struct HomeView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-
-            Button {
-                selectedTab = .contact
-                closeDrawer()
-            } label: {
-                HStack(spacing: 12) {
-                    Circle()
-                        .fill(Color.teal.opacity(0.14))
-                        .frame(width: 42, height: 42)
-                        .overlay {
-                            Image(systemName: "person.crop.circle.fill")
-                                .foregroundStyle(.teal)
-                        }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Open account")
-                            .font(.headline)
-                            .foregroundStyle(.primary)
-                        Text("Manage sign-in and profile details")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.footnote.weight(.semibold))
-                        .foregroundStyle(.tertiary)
-                }
-                .padding(16)
-                .background(
-                    RoundedRectangle(cornerRadius: 24, style: .continuous)
-                        .fill(.regularMaterial)
-                )
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open account")
-            .accessibilityIdentifier("drawer.account")
         }
         .padding(.horizontal, 20)
         .padding(.top, 28)
+    }
+
+    private var newChatButton: some View {
+        Button {
+            selectedTab = .healthAssistant
+            requestedConversationID = nil
+            newChatRequestID = UUID()
+            closeDrawer()
+        } label: {
+            Label("New chat", systemImage: "square.and.pencil")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 14)
+                .background(Color.white.opacity(0.8), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 14)
+        .accessibilityIdentifier("drawer.new-chat")
+    }
+
+    private func drawerChatRow(_ chat: OmerChatSummary) -> some View {
+        Button {
+            selectedTab = .healthAssistant
+            requestedConversationID = chat.id
+            closeDrawer()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "bubble.left")
+                    .foregroundStyle(.secondary)
+                Text(chat.title)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("drawer.chat.\(chat.id.uuidString)")
     }
 
     private func drawerRow(for tab: Tabs) -> some View {
@@ -288,23 +332,8 @@ struct HomeView: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(tab.title)
-        .accessibilityIdentifier("drawer.\(tab.rawValue)")
+        .accessibilityIdentifier(tab == .contact ? "drawer.account" : "drawer.\(tab.rawValue)")
         .padding(.horizontal, 14)
-    }
-
-    private var drawerFooter: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Quick Note")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .textCase(.uppercase)
-
-            Text("Use the drawer for major destinations, and keep feature settings deeper inside each area. This gives the app a cleaner hierarchy than the old bottom tab bar.")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(20)
     }
 
     private var drawerToggleButton: some View {
@@ -326,6 +355,16 @@ struct HomeView: View {
 
     private func closeDrawer() {
         isDrawerOpen = false
+    }
+
+    @MainActor
+    private func loadDrawerChatHistory() async {
+        drawerChatHistory = await OmerChatService.shared.cachedChats()
+        isRefreshingChatHistory = true
+        defer { isRefreshingChatHistory = false }
+        if let remoteChats = try? await OmerChatService.shared.fetchChats(limit: 50).chats {
+            drawerChatHistory = remoteChats
+        }
     }
 }
 

--- a/S2Y/HomeView.swift
+++ b/S2Y/HomeView.swift
@@ -164,22 +164,31 @@ struct HomeView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     newChatButton
 
-                    Text("Recent chats")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .textCase(.uppercase)
-                        .padding(.horizontal, 24)
-                        .padding(.top, 12)
-
                     if drawerChatHistory.isEmpty {
+                        Text("Recent chats")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+                            .padding(.horizontal, 24)
+                            .padding(.top, 12)
+
                         Text(isRefreshingChatHistory ? "Loading conversations…" : "Your Omer and on-device chats will appear here.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 24)
                             .padding(.vertical, 8)
                     } else {
-                        ForEach(drawerChatHistory.prefix(20)) { chat in
-                            drawerChatRow(chat)
+                        ForEach(chatHistorySections) { section in
+                            Text(section.title)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .textCase(.uppercase)
+                                .padding(.horizontal, 24)
+                                .padding(.top, 12)
+
+                            ForEach(section.chats) { chat in
+                                drawerChatRow(chat)
+                            }
                         }
                     }
 
@@ -355,6 +364,10 @@ struct HomeView: View {
 
     private func closeDrawer() {
         isDrawerOpen = false
+    }
+
+    private var chatHistorySections: [OmerChatHistorySection] {
+        OmerChatHistorySection.grouped(Array(drawerChatHistory.prefix(20)))
     }
 
     @MainActor

--- a/S2Y/LLM/Omer/OmerChatModels.swift
+++ b/S2Y/LLM/Omer/OmerChatModels.swift
@@ -96,11 +96,87 @@ struct OmerAgentsResponse: Decodable {
     let agents: [OmerAgent]
 }
 
-struct OmerChatSummary: Codable, Identifiable, Sendable {
+struct OmerChatSummary: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     let createdAt: String
     let title: String
     let visibility: String
+}
+
+struct OmerChatHistorySection: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let chats: [OmerChatSummary]
+
+    static func grouped(
+        _ chats: [OmerChatSummary],
+        relativeTo now: Date = .now,
+        calendar: Calendar = .current
+    ) -> [OmerChatHistorySection] {
+        let buckets = Dictionary(grouping: chats) { chat in
+            section(for: chat.createdAt, relativeTo: now, calendar: calendar)
+        }
+
+        return Section.allCases.compactMap { section in
+            guard let sectionChats = buckets[section], !sectionChats.isEmpty else {
+                return nil
+            }
+            return OmerChatHistorySection(
+                id: section.rawValue,
+                title: section.title,
+                chats: sectionChats
+            )
+        }
+    }
+
+    private static func section(
+        for timestamp: String,
+        relativeTo now: Date,
+        calendar: Calendar
+    ) -> Section {
+        guard let date = ISO8601DateFormatter.s2yDate(from: timestamp) else {
+            return .earlier
+        }
+
+        if calendar.isDate(date, inSameDayAs: now) {
+            return .today
+        }
+        if let yesterday = calendar.date(byAdding: .day, value: -1, to: now),
+           calendar.isDate(date, inSameDayAs: yesterday) {
+            return .yesterday
+        }
+        if let weekAgo = calendar.date(byAdding: .day, value: -7, to: now), date >= weekAgo {
+            return .previousSevenDays
+        }
+        return .earlier
+    }
+
+    private enum Section: String, CaseIterable {
+        case today
+        case yesterday
+        case previousSevenDays
+        case earlier
+
+        var title: String {
+            switch self {
+            case .today: "Today"
+            case .yesterday: "Yesterday"
+            case .previousSevenDays: "Previous 7 days"
+            case .earlier: "Earlier"
+            }
+        }
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static func s2yDate(from timestamp: String) -> Date? {
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractionalFormatter.date(from: timestamp) {
+            return date
+        }
+        return ISO8601DateFormatter().date(from: timestamp)
+    }
 }
 
 struct OmerChatListResponse: Decodable, Sendable {

--- a/S2Y/LLM/Omer/OmerChatModels.swift
+++ b/S2Y/LLM/Omer/OmerChatModels.swift
@@ -96,7 +96,7 @@ struct OmerAgentsResponse: Decodable {
     let agents: [OmerAgent]
 }
 
-struct OmerChatSummary: Decodable, Identifiable, Sendable {
+struct OmerChatSummary: Codable, Identifiable, Sendable {
     let id: UUID
     let createdAt: String
     let title: String
@@ -108,16 +108,21 @@ struct OmerChatListResponse: Decodable, Sendable {
     let hasMore: Bool
 }
 
-struct OmerChatHistoryMessage: Decodable, Identifiable, Sendable {
+struct OmerChatHistoryMessage: Codable, Identifiable, Sendable {
     let id: UUID
     let role: String
     let content: String
     let createdAt: String
 }
 
-struct OmerChatDetailResponse: Decodable, Sendable {
+struct OmerChatDetailResponse: Codable, Sendable {
     let chat: OmerChatSummary
     let messages: [OmerChatHistoryMessage]
+}
+
+struct OmerChatCacheSnapshot: Codable, Sendable {
+    var chats: [OmerChatSummary]
+    var details: [OmerChatDetailResponse]
 }
 
 struct OmerAPIErrorResponse: Decodable {

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -19,8 +19,18 @@ actor OmerChatService {
     private let sessionStore = OmerSessionStore.shared
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
+    private let cacheURL: URL
+    private var chatCache: OmerChatCacheSnapshot
 
-    private init() {}
+    private init() {
+        let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let cacheDirectory = applicationSupport.appendingPathComponent("OmerChatCache", isDirectory: true)
+        let historyURL = cacheDirectory.appendingPathComponent("history.json")
+        self.cacheURL = historyURL
+        self.chatCache = (try? Data(contentsOf: historyURL))
+            .flatMap { try? JSONDecoder().decode(OmerChatCacheSnapshot.self, from: $0) }
+            ?? OmerChatCacheSnapshot(chats: [], details: [])
+    }
 
     func sendMessage(
         message: String,
@@ -64,11 +74,19 @@ actor OmerChatService {
             )
         }
 
-        let assistantMessageID = UUID().uuidString
+        let assistantMessageID = UUID()
+        cacheExchange(
+            conversationID: response.conversationId,
+            userMessageID: body.message.id,
+            userText: message,
+            assistantMessageID: assistantMessageID,
+            assistantText: response.answer,
+            visibility: "private"
+        )
         onEvent(.started(.init(
             chatId: response.conversationId.uuidString,
             userMessageId: body.message.id.uuidString,
-            assistantMessageId: assistantMessageID
+            assistantMessageId: assistantMessageID.uuidString
         )))
         onEvent(.delta(response.answer))
         for toolEvent in response.toolEvents {
@@ -88,7 +106,7 @@ actor OmerChatService {
         await sessionStore.saveLastChatId(response.conversationId.uuidString, sessionKey: sessionKey)
         onEvent(.completed(.init(
             chatId: response.conversationId.uuidString,
-            assistantMessageId: assistantMessageID
+            assistantMessageId: assistantMessageID.uuidString
         )))
     }
 
@@ -133,7 +151,9 @@ actor OmerChatService {
             throw OmerChatServiceError.invalidBaseURL
         }
         let data = try await authenticatedGET(url: url)
-        return try decoder.decode(OmerChatListResponse.self, from: data)
+        let response = try decoder.decode(OmerChatListResponse.self, from: data)
+        mergeCachedSummaries(response.chats)
+        return response
     }
 
     func fetchChat(id: UUID) async throws -> OmerChatDetailResponse {
@@ -142,7 +162,17 @@ actor OmerChatService {
             .appendingPathComponent("api/mobile/v1/chats")
             .appendingPathComponent(id.uuidString)
         let data = try await authenticatedGET(url: url)
-        return try decoder.decode(OmerChatDetailResponse.self, from: data)
+        let detail = try decoder.decode(OmerChatDetailResponse.self, from: data)
+        cacheDetail(detail)
+        return detail
+    }
+
+    func cachedChats(limit: Int = 50) -> [OmerChatSummary] {
+        Array(chatCache.chats.prefix(max(1, limit)))
+    }
+
+    func cachedChat(id: UUID) -> OmerChatDetailResponse? {
+        chatCache.details.first { $0.chat.id == id }
     }
 
     func selectChat(id: UUID) async throws {
@@ -180,8 +210,92 @@ actor OmerChatService {
         } catch OmerChatServiceError.unauthorized {
             response = try await performLocalSync(request, url: url, forceTokenRefresh: true)
         }
+        cacheExchange(
+            conversationID: response.conversationId,
+            userMessageID: userMessageID,
+            userText: userText,
+            assistantMessageID: assistantMessageID,
+            assistantText: assistantText,
+            visibility: "private"
+        )
         await sessionStore.saveLastChatId(response.conversationId.uuidString, sessionKey: key)
         return response
+    }
+
+    private func cacheExchange(
+        conversationID: UUID,
+        userMessageID: UUID,
+        userText: String,
+        assistantMessageID: UUID,
+        assistantText: String,
+        visibility: String
+    ) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let existingSummary = chatCache.chats.first { $0.id == conversationID }
+        let title = existingSummary?.title ?? conversationTitle(from: userText)
+        let summary = OmerChatSummary(
+            id: conversationID,
+            createdAt: existingSummary?.createdAt ?? timestamp,
+            title: title,
+            visibility: existingSummary?.visibility ?? visibility
+        )
+        let newMessages = [
+            OmerChatHistoryMessage(id: userMessageID, role: "user", content: userText, createdAt: timestamp),
+            OmerChatHistoryMessage(id: assistantMessageID, role: "assistant", content: assistantText, createdAt: timestamp)
+        ]
+
+        if let detailIndex = chatCache.details.firstIndex(where: { $0.chat.id == conversationID }) {
+            let existing = chatCache.details[detailIndex]
+            let uniqueMessages = (existing.messages + newMessages).reduce(into: [OmerChatHistoryMessage]()) { result, message in
+                if !result.contains(where: { $0.id == message.id }) {
+                    result.append(message)
+                }
+            }
+            chatCache.details[detailIndex] = OmerChatDetailResponse(chat: summary, messages: Array(uniqueMessages.suffix(200)))
+        } else {
+            chatCache.details.insert(OmerChatDetailResponse(chat: summary, messages: newMessages), at: 0)
+        }
+        mergeCachedSummaries([summary])
+    }
+
+    private func cacheDetail(_ detail: OmerChatDetailResponse) {
+        if let index = chatCache.details.firstIndex(where: { $0.chat.id == detail.chat.id }) {
+            chatCache.details[index] = detail
+        } else {
+            chatCache.details.insert(detail, at: 0)
+        }
+        chatCache.details = Array(chatCache.details.prefix(50))
+        mergeCachedSummaries([detail.chat])
+    }
+
+    private func mergeCachedSummaries(_ summaries: [OmerChatSummary]) {
+        var merged = summaries
+        merged.append(contentsOf: chatCache.chats.filter { cached in
+            !summaries.contains(where: { $0.id == cached.id })
+        })
+        chatCache.chats = Array(merged.prefix(50))
+        persistCache()
+    }
+
+    private func conversationTitle(from text: String) -> String {
+        let firstLine = text.split(whereSeparator: \.isNewline).first.map(String.init) ?? text
+        let trimmed = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count > 64 ? String(trimmed.prefix(61)) + "…" : trimmed
+    }
+
+    private func persistCache() {
+        do {
+            let directory = cacheURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            var mutableDirectory = directory
+            try? mutableDirectory.setResourceValues(resourceValues)
+            let data = try encoder.encode(chatCache)
+            try data.write(to: cacheURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+        } catch {
+            logger.error("Failed to persist protected Omer chat cache: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func configuredServiceURL() throws -> URL {

--- a/S2Y/SharedContext/StorageKeys.swift
+++ b/S2Y/SharedContext/StorageKeys.swift
@@ -34,6 +34,8 @@ enum StorageKeys {
     static let cloudflareModelPath = "cf.model-path"
     /// Whether Health Assistant should attach summarized health context to Omer requests.
     static let omerIncludeHealthContext = "omer.include-health-context"
+    /// User-selected Health Assistant inference route: on-device Apple AI or Omer online.
+    static let healthAssistantAIMode = "health-assistant.ai-mode"
     /// Enable or disable voice features globally
     static let voiceEnabled = "voice.enabled"
     /// Speak assistant responses using TTS

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -231,4 +231,12 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(sections.map(\.title), ["Today", "Yesterday", "Previous 7 days", "Earlier"])
         XCTAssertEqual(sections.flatMap(\.chats).map(\.title), ["Today", "Yesterday", "This week", "Earlier"])
     }
+
+    func testHealthSuggestionsOnlyIncludeAvailableMetrics() {
+        let suggestions = HealthQuickQuerySuggestion.available(for: [.steps, .sleepDurationHours])
+
+        XCTAssertEqual(suggestions.map(\.id), ["steps", "sleep"])
+        XCTAssertFalse(suggestions.contains(where: { $0.metricKind == .heartRateAverage }))
+        XCTAssertFalse(suggestions.contains(where: { $0.metricKind == .activeEnergy }))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -239,4 +239,27 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertFalse(suggestions.contains(where: { $0.metricKind == .heartRateAverage }))
         XCTAssertFalse(suggestions.contains(where: { $0.metricKind == .activeEnergy }))
     }
+
+    func testAssistantMarkdownCreatesUserFriendlyBlocks() {
+        let markdown = """
+        # Sleep summary
+
+        **Average:** 7.5 hours
+
+        - Keep a consistent bedtime
+        2. Review again next week
+
+        > This is a wellness insight, not a diagnosis.
+        """
+
+        let blocks = ChatMarkdownRenderer.blocks(from: markdown)
+
+        XCTAssertEqual(
+            blocks.map(\.kind),
+            [.heading(1), .paragraph, .unorderedListItem, .orderedListItem(2), .quote]
+        )
+        XCTAssertEqual(String(blocks[0].content.characters), "Sleep summary")
+        XCTAssertEqual(String(blocks[1].content.characters), "Average: 7.5 hours")
+        XCTAssertFalse(blocks.map { String($0.content.characters) }.joined().contains("**"))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -172,4 +172,46 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(response.conversationId, conversationID)
         XCTAssertTrue(response.synced)
     }
+
+    func testLocalChatCacheRoundTripsConversationContent() throws {
+        let chatID = try XCTUnwrap(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let messageID = try XCTUnwrap(UUID(uuidString: "33333333-3333-4333-8333-333333333333"))
+        let summary = OmerChatSummary(
+            id: chatID,
+            createdAt: "2026-08-12T12:00:00Z",
+            title: "Sleep quality",
+            visibility: "private"
+        )
+        let snapshot = OmerChatCacheSnapshot(
+            chats: [summary],
+            details: [
+                OmerChatDetailResponse(
+                    chat: summary,
+                    messages: [
+                        OmerChatHistoryMessage(
+                            id: messageID,
+                            role: "assistant",
+                            content: "**Average:** 7.5 hours",
+                            createdAt: "2026-08-12T12:00:01Z"
+                        )
+                    ]
+                )
+            ]
+        )
+
+        let decoded = try decoder.decode(OmerChatCacheSnapshot.self, from: encoder.encode(snapshot))
+        XCTAssertEqual(decoded.chats.first?.id, chatID)
+        XCTAssertEqual(decoded.details.first?.messages.first?.content, "**Average:** 7.5 hours")
+    }
+
+    func testAssistantMarkdownIsConvertedToDisplayText() throws {
+        let markdown = "**Average sleep:** 7.5 hours\n\nYour consistency is *improving*."
+        let rendered = try XCTUnwrap(ChatMarkdownRenderer.attributedString(from: markdown))
+        let displayText = String(rendered.characters)
+
+        XCTAssertTrue(displayText.contains("Average sleep:"))
+        XCTAssertTrue(displayText.contains("improving"))
+        XCTAssertFalse(displayText.contains("**"))
+        XCTAssertFalse(displayText.contains("*improving*"))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -214,4 +214,21 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertFalse(displayText.contains("**"))
         XCTAssertFalse(displayText.contains("*improving*"))
     }
+
+    func testChatHistoryGroupsConversationsByRelativeDate() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let chats = [
+            OmerChatSummary(id: UUID(), createdAt: "2026-08-12T12:00:00.000Z", title: "Today", visibility: "private"),
+            OmerChatSummary(id: UUID(), createdAt: "2026-08-11T12:00:00.000Z", title: "Yesterday", visibility: "private"),
+            OmerChatSummary(id: UUID(), createdAt: "2026-08-08T12:00:00.000Z", title: "This week", visibility: "private"),
+            OmerChatSummary(id: UUID(), createdAt: "invalid", title: "Earlier", visibility: "private")
+        ]
+
+        let sections = OmerChatHistorySection.grouped(chats, relativeTo: now, calendar: calendar)
+
+        XCTAssertEqual(sections.map(\.title), ["Today", "Yesterday", "Previous 7 days", "Earlier"])
+        XCTAssertEqual(sections.flatMap(\.chats).map(\.title), ["Today", "Yesterday", "This week", "Earlier"])
+    }
 }

--- a/S2YUITests/ContributionsTest.swift
+++ b/S2YUITests/ContributionsTest.swift
@@ -43,12 +43,49 @@ final class ContributionsTest: XCTestCase {
 
 final class HealthAssistantChatUITests: XCTestCase {
     @MainActor
-    func testOmerFallbackRespondsInSimulator() {
+    func testChatControlsAndDrawer() {
         let app = XCUIApplication()
         app.launchArguments = ["--setupTestAccount", "--skipOnboarding"]
         app.launch()
 
-        XCTAssertTrue(app.staticTexts["Omer fallback"].waitForExistence(timeout: 10))
+        let providerMenu = app.buttons["health-assistant-ai-mode"]
+        XCTAssertTrue(providerMenu.waitForExistence(timeout: 10))
+        providerMenu.tap()
+        XCTAssertTrue(app.buttons["Omer Online"].waitForExistence(timeout: 3))
+        app.buttons["Omer Online"].tap()
+        XCTAssertTrue(app.staticTexts["Omer Online"].waitForExistence(timeout: 3))
+
+        let input = app.textFields["health-assistant-input"]
+        XCTAssertTrue(input.waitForExistence(timeout: 5))
+        input.tap()
+        input.typeText("How has my sleep quality been recently?")
+        XCTAssertTrue(app.keyboards.firstMatch.exists)
+        XCTAssertTrue(app.toolbars.buttons["Done"].waitForExistence(timeout: 3))
+        app.toolbars.buttons["Done"].tap()
+        XCTAssertFalse(app.keyboards.firstMatch.waitForExistence(timeout: 1))
+
+        app.openHomeDrawer()
+        XCTAssertTrue(app.buttons["drawer.new-chat"].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "Recent chats")).firstMatch.exists
+        )
+        app.swipeUp()
+        app.swipeUp()
+        XCTAssertTrue(app.buttons["drawer.account"].waitForExistence(timeout: 3))
+        XCTAssertEqual(app.buttons.matching(identifier: "drawer.account").count, 1)
+    }
+
+    @MainActor
+    func testOmerOnlineRespondsInSimulator() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--setupTestAccount", "--skipOnboarding"]
+        app.launch()
+
+        let providerMenu = app.buttons["health-assistant-ai-mode"]
+        XCTAssertTrue(providerMenu.waitForExistence(timeout: 10))
+        providerMenu.tap()
+        XCTAssertTrue(app.buttons["Omer Online"].waitForExistence(timeout: 3))
+        app.buttons["Omer Online"].tap()
 
         let input = app.textFields["health-assistant-input"]
         XCTAssertTrue(input.waitForExistence(timeout: 5))

--- a/S2YUITests/ContributionsTest.swift
+++ b/S2YUITests/ContributionsTest.swift
@@ -66,9 +66,8 @@ final class HealthAssistantChatUITests: XCTestCase {
 
         app.openHomeDrawer()
         XCTAssertTrue(app.buttons["drawer.new-chat"].waitForExistence(timeout: 5))
-        XCTAssertTrue(
-            app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "Recent chats")).firstMatch.exists
-        )
+        let expectedChatSectionLabels = ["Recent chats", "Today", "Yesterday", "Previous 7 days", "Earlier"]
+        XCTAssertTrue(expectedChatSectionLabels.contains { app.staticTexts[$0].exists })
         app.swipeUp()
         app.swipeUp()
         XCTAssertTrue(app.buttons["drawer.account"].waitForExistence(timeout: 3))


### PR DESCRIPTION
## Theme
Simplifies the Health Assistant around chat, relevant Health data, history, and user-facing responses.

## User stories
- HLT-000 stabilizes provider selection, keyboard dismissal, local/online history, and chat controls.
- HLT-001 removes developer-oriented settings and redundant Health Assistant UI.
- HLT-002 groups cached and Omer conversations by relative date in the drawer.
- HLT-003 only offers quick questions backed by Health data available on the device.
- HLT-004 renders headings, lists, quotes, code, and inline Markdown as native SwiftUI content.

## Validation
- Generic iOS build with signing disabled
- OmerMobileChatModelsTests on iPhone 17 Pro simulator
- HealthAssistantChatUITests.testChatControlsAndDrawer on iPhone 17 Pro simulator

## Scope note
The untracked BrandAssets directory is intentionally excluded.