### PR TITLE
EPIC-H02: Establish health data connections and permissions

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -408,16 +408,7 @@ struct HealthAssistantView: View {
             return
         }
 
-        do {
-            try await healthService.requestAuthorization()
-            await loadQuickQueryAvailability()
-        } catch {
-            didLoadSuggestionAvailability = true
-            notice = AssistantNotice(
-                message: "HealthKit authorization failed: \(error.localizedDescription)",
-                tone: .warning
-            )
-        }
+        await loadQuickQueryAvailability()
     }
 
     private func loadQuickQueryAvailability() async {

--- a/S2Y/HealthKit/ClinicalRecordsService.swift
+++ b/S2Y/HealthKit/ClinicalRecordsService.swift
@@ -1,0 +1,119 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import HealthKit
+
+public enum ClinicalRecordCategory: String, CaseIterable, Identifiable, Sendable {
+    case allergies
+    case conditions
+    case immunizations
+    case labResults
+    case medications
+    case procedures
+    case vitalSigns
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .allergies: "Allergies"
+        case .conditions: "Conditions"
+        case .immunizations: "Immunizations"
+        case .labResults: "Lab Results"
+        case .medications: "Medications"
+        case .procedures: "Procedures"
+        case .vitalSigns: "Clinical Vital Signs"
+        }
+    }
+
+    var clinicalType: HKClinicalType? {
+        switch self {
+        case .allergies:
+            HKObjectType.clinicalType(forIdentifier: .allergyRecord)
+        case .conditions:
+            HKObjectType.clinicalType(forIdentifier: .conditionRecord)
+        case .immunizations:
+            HKObjectType.clinicalType(forIdentifier: .immunizationRecord)
+        case .labResults:
+            HKObjectType.clinicalType(forIdentifier: .labResultRecord)
+        case .medications:
+            HKObjectType.clinicalType(forIdentifier: .medicationRecord)
+        case .procedures:
+            HKObjectType.clinicalType(forIdentifier: .procedureRecord)
+        case .vitalSigns:
+            HKObjectType.clinicalType(forIdentifier: .vitalSignRecord)
+        }
+    }
+}
+
+public struct ClinicalRecordSummary: Codable, Equatable, Identifiable, Sendable {
+    public let id: UUID
+    public let category: ClinicalRecordCategory
+    public let displayName: String
+    public let recordedAt: Date
+    public let sourceName: String
+    public let fhirResourceIdentifier: String?
+}
+
+extension ClinicalRecordCategory: Codable {}
+
+extension HealthKitService {
+    public func requestClinicalRecordAuthorization(
+        for categories: Set<ClinicalRecordCategory>
+    ) async throws {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            throw HealthKitError.notAvailable
+        }
+        let readTypes = Set(categories.compactMap(\.clinicalType))
+        guard !readTypes.isEmpty else {
+            return
+        }
+        do {
+            try await healthStore.requestAuthorization(toShare: [], read: readTypes)
+        } catch {
+            throw HealthKitError.authorizationFailed
+        }
+    }
+
+    public func fetchClinicalRecordSummaries(
+        for category: ClinicalRecordCategory,
+        limit: Int = 50
+    ) async throws -> [ClinicalRecordSummary] {
+        guard let clinicalType = category.clinicalType else {
+            return []
+        }
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+        let records: [HKClinicalRecord] = try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: clinicalType,
+                predicate: nil,
+                limit: limit,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    continuation.resume(throwing: HealthKitError.queryFailed(error))
+                    return
+                }
+                continuation.resume(returning: samples as? [HKClinicalRecord] ?? [])
+            }
+            healthStore.execute(query)
+        }
+
+        return records.map { record in
+            ClinicalRecordSummary(
+                id: record.uuid,
+                category: category,
+                displayName: record.displayName,
+                recordedAt: record.startDate,
+                sourceName: record.sourceRevision.source.name,
+                fhirResourceIdentifier: record.fhirResource?.identifier
+            )
+        }
+    }
+}

--- a/S2Y/HealthKit/HealthKitService.swift
+++ b/S2Y/HealthKit/HealthKitService.swift
@@ -32,6 +32,85 @@ public enum HealthKitError: Error, LocalizedError {
     }
 }
 
+public enum HealthPermissionGroup: String, CaseIterable, Identifiable, Sendable {
+    case activity
+    case sleep
+    case heart
+    case vitals
+    case body
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .activity: "Activity"
+        case .sleep: "Sleep"
+        case .heart: "Heart & Fitness"
+        case .vitals: "Vitals"
+        case .body: "Body Measurements"
+        }
+    }
+
+    public var purpose: String {
+        switch self {
+        case .activity:
+            "Understand movement, exercise, and energy trends."
+        case .sleep:
+            "Summarize sleep duration and consistency."
+        case .heart:
+            "Explain heart-rate, recovery, and cardio-fitness trends."
+        case .vitals:
+            "Review blood pressure, temperature, breathing, and oxygen trends."
+        case .body:
+            "Track changes in body measurements over time."
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .activity: "figure.walk"
+        case .sleep: "bed.double"
+        case .heart: "heart"
+        case .vitals: "waveform.path.ecg"
+        case .body: "scalemass"
+        }
+    }
+
+    public var metricKinds: [HealthKitService.MetricKind] {
+        switch self {
+        case .activity:
+            [.steps, .activeEnergy]
+        case .sleep:
+            [.sleepDurationHours]
+        case .heart:
+            [
+                .heartRateAverage,
+                .restingHeartRate,
+                .heartRateVariability,
+                .heartRateRecovery,
+                .vo2Max,
+                .walkingHeartRateAverage
+            ]
+        case .vitals:
+            [
+                .oxygenSaturation,
+                .bloodPressureSystolic,
+                .bloodPressureDiastolic,
+                .bodyTemperature,
+                .respiratoryRate
+            ]
+        case .body:
+            [.bodyMass]
+        }
+    }
+}
+
+public enum HealthPermissionRequestState: Sendable {
+    case review
+    case requested
+    case unavailable
+}
+
 @MainActor
 public final class HealthKitService {
     public static let shared = HealthKitService()
@@ -42,33 +121,19 @@ public final class HealthKitService {
     private init() {}
 
     public func requestAuthorization() async throws {
+        try await requestAuthorization(for: Set(HealthPermissionGroup.allCases))
+    }
+
+    public func requestAuthorization(for groups: Set<HealthPermissionGroup>) async throws {
         guard HKHealthStore.isHealthDataAvailable() else { 
             logger.error("HealthKit not available on this device")
             throw HealthKitError.notAvailable
         }
 
-        let readTypes: Set<HKObjectType> = [
-            // Basic metrics
-            HKObjectType.quantityType(forIdentifier: .stepCount)!,
-            HKObjectType.quantityType(forIdentifier: .heartRate)!,
-            HKObjectType.quantityType(forIdentifier: .restingHeartRate)!,
-            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
-            HKObjectType.quantityType(forIdentifier: .bodyMass)!,
-            HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!,
-            
-            // Advanced cardiac metrics
-            HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
-            HKObjectType.quantityType(forIdentifier: .heartRateRecoveryOneMinute)!,
-            HKObjectType.quantityType(forIdentifier: .vo2Max)!,
-            HKObjectType.quantityType(forIdentifier: .walkingHeartRateAverage)!,
-            HKObjectType.quantityType(forIdentifier: .oxygenSaturation)!,
-            
-            // Blood pressure and vitals
-            HKObjectType.quantityType(forIdentifier: .bloodPressureSystolic)!,
-            HKObjectType.quantityType(forIdentifier: .bloodPressureDiastolic)!,
-            HKObjectType.quantityType(forIdentifier: .bodyTemperature)!,
-            HKObjectType.quantityType(forIdentifier: .respiratoryRate)!
-        ]
+        let readTypes = readTypes(for: groups)
+        guard !readTypes.isEmpty else {
+            return
+        }
 
         do {
             try await healthStore.requestAuthorization(toShare: [], read: readTypes)
@@ -76,6 +141,71 @@ public final class HealthKitService {
         } catch {
             logger.error("HealthKit authorization failed: \(error.localizedDescription)")
             throw HealthKitError.authorizationFailed
+        }
+    }
+
+    public func permissionRequestState(for group: HealthPermissionGroup) async -> HealthPermissionRequestState {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            return .unavailable
+        }
+
+        do {
+            let status = try await healthStore.statusForAuthorizationRequest(
+                toShare: [],
+                read: readTypes(for: [group])
+            )
+            switch status {
+            case .shouldRequest:
+                return .review
+            case .unnecessary:
+                return .requested
+            case .unknown:
+                return .review
+            @unknown default:
+                return .review
+            }
+        } catch {
+            logger.error("Could not determine Health authorization request state: \(error.localizedDescription)")
+            return .review
+        }
+    }
+
+    private func readTypes(for groups: Set<HealthPermissionGroup>) -> Set<HKObjectType> {
+        Set(groups.flatMap(\.metricKinds).compactMap(healthObjectType(for:)))
+    }
+
+    private func healthObjectType(for kind: MetricKind) -> HKObjectType? {
+        switch kind {
+        case .steps:
+            HKObjectType.quantityType(forIdentifier: .stepCount)
+        case .heartRateAverage:
+            HKObjectType.quantityType(forIdentifier: .heartRate)
+        case .restingHeartRate:
+            HKObjectType.quantityType(forIdentifier: .restingHeartRate)
+        case .activeEnergy:
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)
+        case .bodyMass:
+            HKObjectType.quantityType(forIdentifier: .bodyMass)
+        case .sleepDurationHours:
+            HKObjectType.categoryType(forIdentifier: .sleepAnalysis)
+        case .heartRateVariability:
+            HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)
+        case .heartRateRecovery:
+            HKObjectType.quantityType(forIdentifier: .heartRateRecoveryOneMinute)
+        case .vo2Max:
+            HKObjectType.quantityType(forIdentifier: .vo2Max)
+        case .walkingHeartRateAverage:
+            HKObjectType.quantityType(forIdentifier: .walkingHeartRateAverage)
+        case .oxygenSaturation:
+            HKObjectType.quantityType(forIdentifier: .oxygenSaturation)
+        case .bloodPressureSystolic:
+            HKObjectType.quantityType(forIdentifier: .bloodPressureSystolic)
+        case .bloodPressureDiastolic:
+            HKObjectType.quantityType(forIdentifier: .bloodPressureDiastolic)
+        case .bodyTemperature:
+            HKObjectType.quantityType(forIdentifier: .bodyTemperature)
+        case .respiratoryRate:
+            HKObjectType.quantityType(forIdentifier: .respiratoryRate)
         }
     }
 

--- a/S2Y/HealthKit/HealthKitService.swift
+++ b/S2Y/HealthKit/HealthKitService.swift
@@ -145,7 +145,9 @@ public struct HealthMetricProvenance: Identifiable, Sendable {
 public final class HealthKitService {
     public static let shared = HealthKitService()
 
-    private let healthStore = HKHealthStore()
+    // Internal so focused HealthKit extensions (for example, clinical records)
+    // can share the same store without exposing it outside the app module.
+    let healthStore = HKHealthStore()
     private let logger = Logger(subsystem: "com.s2y.app", category: "HealthKit")
 
     private init() {}

--- a/S2Y/HealthKit/HealthKitService.swift
+++ b/S2Y/HealthKit/HealthKitService.swift
@@ -111,6 +111,36 @@ public enum HealthPermissionRequestState: Sendable {
     case unavailable
 }
 
+public struct HealthMetricProvenance: Identifiable, Sendable {
+    public enum Freshness: String, Sendable {
+        case current = "Current"
+        case aging = "Getting old"
+        case stale = "Out of date"
+    }
+
+    public let metricKind: HealthKitService.MetricKind
+    public let sourceName: String
+    public let deviceName: String?
+    public let updatedAt: Date
+    public let freshness: Freshness
+
+    public var id: HealthKitService.MetricKind { metricKind }
+
+    public static func freshness(
+        for updatedAt: Date,
+        relativeTo now: Date = .now
+    ) -> Freshness {
+        let age = max(0, now.timeIntervalSince(updatedAt))
+        if age <= 48 * 60 * 60 {
+            return .current
+        }
+        if age <= 7 * 24 * 60 * 60 {
+            return .aging
+        }
+        return .stale
+    }
+}
+
 @MainActor
 public final class HealthKitService {
     public static let shared = HealthKitService()
@@ -168,6 +198,40 @@ public final class HealthKitService {
             logger.error("Could not determine Health authorization request state: \(error.localizedDescription)")
             return .review
         }
+    }
+
+    public func latestProvenance(for kind: MetricKind) async throws -> HealthMetricProvenance? {
+        guard let sampleType = healthObjectType(for: kind) as? HKSampleType else {
+            return nil
+        }
+
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+        let samples: [HKSample] = try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: sampleType,
+                predicate: nil,
+                limit: 1,
+                sortDescriptors: [sort]
+            ) { _, samples, error in
+                if let error {
+                    continuation.resume(throwing: HealthKitError.queryFailed(error))
+                    return
+                }
+                continuation.resume(returning: samples ?? [])
+            }
+            healthStore.execute(query)
+        }
+
+        guard let sample = samples.first else {
+            return nil
+        }
+        return HealthMetricProvenance(
+            metricKind: kind,
+            sourceName: sample.sourceRevision.source.name,
+            deviceName: sample.device?.name ?? sample.device?.model,
+            updatedAt: sample.endDate,
+            freshness: HealthMetricProvenance.freshness(for: sample.endDate)
+        )
     }
 
     private func readTypes(for groups: Set<HealthPermissionGroup>) -> Set<HKObjectType> {

--- a/S2Y/HealthKit/WearableMeasurementNormalizer.swift
+++ b/S2Y/HealthKit/WearableMeasurementNormalizer.swift
@@ -1,0 +1,205 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public struct WearableMeasurementInput: Sendable {
+    public let id: String
+    public let metricIdentifier: String
+    public let value: Double
+    public let unit: String
+    public let startDate: Date
+    public let endDate: Date
+    public let timeZoneIdentifier: String
+    public let sourceIdentifier: String
+    public let sourceName: String
+    public let deviceName: String?
+    public let syncIdentifier: String?
+    public let syncVersion: Int
+
+    public init(
+        id: String,
+        metricIdentifier: String,
+        value: Double,
+        unit: String,
+        startDate: Date,
+        endDate: Date,
+        timeZoneIdentifier: String,
+        sourceIdentifier: String,
+        sourceName: String,
+        deviceName: String? = nil,
+        syncIdentifier: String? = nil,
+        syncVersion: Int = 0
+    ) {
+        self.id = id
+        self.metricIdentifier = metricIdentifier
+        self.value = value
+        self.unit = unit
+        self.startDate = startDate
+        self.endDate = endDate
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.sourceIdentifier = sourceIdentifier
+        self.sourceName = sourceName
+        self.deviceName = deviceName
+        self.syncIdentifier = syncIdentifier
+        self.syncVersion = syncVersion
+    }
+}
+
+public struct NormalizedWearableMeasurement: Identifiable, Sendable {
+    public let id: String
+    public let metricKind: HealthKitService.MetricKind
+    public let value: Double
+    public let unit: String
+    public let originalValue: Double
+    public let originalUnit: String
+    public let startDate: Date
+    public let endDate: Date
+    public let timeZoneIdentifier: String
+    public let sourceIdentifier: String
+    public let sourceName: String
+    public let deviceName: String?
+    public let syncIdentifier: String?
+    public let syncVersion: Int
+}
+
+public enum WearableMeasurementNormalizer {
+    private struct Conversion {
+        let kind: HealthKitService.MetricKind
+        let canonicalUnit: String
+        let convert: @Sendable (Double, String) -> Double?
+    }
+
+    /// Normalizes known HealthKit-compatible measurements and discards vendor-only scores.
+    /// Measurements from different sources remain separate. A source's repeated sync identifier
+    /// resolves deterministically to its highest sync version.
+    public static func normalize(
+        _ inputs: [WearableMeasurementInput]
+    ) -> [NormalizedWearableMeasurement] {
+        let deduplicated = inputs.reduce(into: [String: WearableMeasurementInput]()) { result, input in
+            let key = input.syncIdentifier.map { "\(input.sourceIdentifier)|\($0)" }
+                ?? "\(input.sourceIdentifier)|sample|\(input.id)"
+            guard let current = result[key] else {
+                result[key] = input
+                return
+            }
+            if input.syncVersion > current.syncVersion {
+                result[key] = input
+            }
+        }
+
+        return deduplicated.values.compactMap(normalizeOne).sorted {
+            if $0.startDate == $1.startDate {
+                return $0.id < $1.id
+            }
+            return $0.startDate < $1.startDate
+        }
+    }
+
+    private static func normalizeOne(
+        _ input: WearableMeasurementInput
+    ) -> NormalizedWearableMeasurement? {
+        guard let conversion = conversions[input.metricIdentifier],
+              let value = conversion.convert(input.value, normalizedUnit(input.unit)) else {
+            return nil
+        }
+        let timeZone = TimeZone(identifier: input.timeZoneIdentifier)?.identifier ?? "UTC"
+        return NormalizedWearableMeasurement(
+            id: input.id,
+            metricKind: conversion.kind,
+            value: value,
+            unit: conversion.canonicalUnit,
+            originalValue: input.value,
+            originalUnit: input.unit,
+            startDate: input.startDate,
+            endDate: input.endDate,
+            timeZoneIdentifier: timeZone,
+            sourceIdentifier: input.sourceIdentifier,
+            sourceName: input.sourceName,
+            deviceName: input.deviceName,
+            syncIdentifier: input.syncIdentifier,
+            syncVersion: input.syncVersion
+        )
+    }
+
+    private static func normalizedUnit(_ unit: String) -> String {
+        unit.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static let conversions: [String: Conversion] = [
+        "HKQuantityTypeIdentifierStepCount": .init(kind: .steps, canonicalUnit: "count") { value, unit in
+            ["count", "steps"].contains(unit) ? value : nil
+        },
+        "HKQuantityTypeIdentifierHeartRate": heartRateConversion(.heartRateAverage),
+        "HKQuantityTypeIdentifierRestingHeartRate": heartRateConversion(.restingHeartRate),
+        "HKQuantityTypeIdentifierWalkingHeartRateAverage": heartRateConversion(.walkingHeartRateAverage),
+        "HKQuantityTypeIdentifierActiveEnergyBurned": .init(kind: .activeEnergy, canonicalUnit: "kcal") { value, unit in
+            switch unit {
+            case "kcal": value
+            case "kj": value / 4.184
+            default: nil
+            }
+        },
+        "HKQuantityTypeIdentifierBodyMass": .init(kind: .bodyMass, canonicalUnit: "kg") { value, unit in
+            switch unit {
+            case "kg": value
+            case "lb", "lbs": value * 0.453_592_37
+            default: nil
+            }
+        },
+        "HKCategoryTypeIdentifierSleepAnalysis": .init(kind: .sleepDurationHours, canonicalUnit: "h") { value, unit in
+            switch unit {
+            case "h", "hr", "hours": value
+            case "min", "minutes": value / 60
+            case "s", "sec", "seconds": value / 3_600
+            default: nil
+            }
+        },
+        "HKQuantityTypeIdentifierHeartRateVariabilitySDNN": .init(kind: .heartRateVariability, canonicalUnit: "ms") { value, unit in
+            switch unit {
+            case "ms": value
+            case "s", "sec": value * 1_000
+            default: nil
+            }
+        },
+        "HKQuantityTypeIdentifierVO2Max": .init(kind: .vo2Max, canonicalUnit: "mL/kg/min") { value, unit in
+            unit == "ml/kg/min" ? value : nil
+        },
+        "HKQuantityTypeIdentifierOxygenSaturation": .init(kind: .oxygenSaturation, canonicalUnit: "%") { value, unit in
+            switch unit {
+            case "%", "percent": value
+            case "ratio": value * 100
+            default: nil
+            }
+        },
+        "HKQuantityTypeIdentifierBloodPressureSystolic": pressureConversion(.bloodPressureSystolic),
+        "HKQuantityTypeIdentifierBloodPressureDiastolic": pressureConversion(.bloodPressureDiastolic),
+        "HKQuantityTypeIdentifierBodyTemperature": .init(kind: .bodyTemperature, canonicalUnit: "°C") { value, unit in
+            switch unit {
+            case "°c", "c": value
+            case "°f", "f": (value - 32) * 5 / 9
+            default: nil
+            }
+        },
+        "HKQuantityTypeIdentifierRespiratoryRate": .init(kind: .respiratoryRate, canonicalUnit: "breaths/min") { value, unit in
+            ["breaths/min", "count/min"].contains(unit) ? value : nil
+        }
+    ]
+
+    private static func heartRateConversion(_ kind: HealthKitService.MetricKind) -> Conversion {
+        .init(kind: kind, canonicalUnit: "bpm") { value, unit in
+            ["bpm", "count/min"].contains(unit) ? value : nil
+        }
+    }
+
+    private static func pressureConversion(_ kind: HealthKitService.MetricKind) -> Conversion {
+        .init(kind: kind, canonicalUnit: "mmHg") { value, unit in
+            unit == "mmhg" ? value : nil
+        }
+    }
+}

--- a/S2Y/Showcase/ShowcaseView.swift
+++ b/S2Y/Showcase/ShowcaseView.swift
@@ -348,6 +348,12 @@ private struct HealthAccessSettingsView: View {
                 ForEach(HealthPermissionGroup.allCases) { group in
                     permissionRow(for: group)
                 }
+
+                NavigationLink {
+                    HealthDataSourcesView()
+                } label: {
+                    Label("Data Sources & Freshness", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                }
             } footer: {
                 Text("S2Y requests each category only when you choose it. Apple does not reveal whether read access was allowed or denied, so S2Y never labels a category as Allowed.")
             }
@@ -431,6 +437,89 @@ private struct HealthAccessSettingsView: View {
     private func refreshRequestStates() async {
         for group in HealthPermissionGroup.allCases {
             requestStates[group] = await healthService.permissionRequestState(for: group)
+        }
+    }
+}
+
+private struct HealthDataSourcesView: View {
+    @State private var provenance: [HealthKitService.MetricKind: HealthMetricProvenance] = [:]
+    @State private var isLoading = true
+
+    private let healthService = HealthKitService.shared
+
+    var body: some View {
+        List {
+            ForEach(HealthPermissionGroup.allCases) { group in
+                Section(group.title) {
+                    ForEach(group.metricKinds, id: \.self) { kind in
+                        provenanceRow(for: kind)
+                    }
+                }
+            }
+        }
+        .overlay {
+            if isLoading {
+                ProgressView("Checking Health data…")
+                    .padding()
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+            }
+        }
+        .navigationTitle("Health Data Sources")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await loadProvenance()
+        }
+    }
+
+    @ViewBuilder
+    private func provenanceRow(for kind: HealthKitService.MetricKind) -> some View {
+        if let item = provenance[kind] {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack {
+                    Text(kind.displayName)
+                    Spacer()
+                    Text(item.freshness.rawValue)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(freshnessColor(item.freshness))
+                }
+                Text(sourceDescription(item))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Text(item.updatedAt, format: .relative(presentation: .named))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        } else if !isLoading {
+            LabeledContent(kind.displayName, value: "No recent readable data")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func sourceDescription(_ item: HealthMetricProvenance) -> String {
+        guard let deviceName = item.deviceName, deviceName != item.sourceName else {
+            return item.sourceName
+        }
+        return "\(item.sourceName) · \(deviceName)"
+    }
+
+    private func freshnessColor(_ freshness: HealthMetricProvenance.Freshness) -> Color {
+        switch freshness {
+        case .current: .green
+        case .aging: .orange
+        case .stale: .secondary
+        }
+    }
+
+    @MainActor
+    private func loadProvenance() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        for kind in HealthKitService.MetricKind.allCases {
+            if let item = try? await healthService.latestProvenance(for: kind) {
+                provenance[kind] = item
+            }
         }
     }
 }

--- a/S2Y/Showcase/ShowcaseView.swift
+++ b/S2Y/Showcase/ShowcaseView.swift
@@ -336,29 +336,23 @@ struct ShowcaseView: View {
 }
 
 private struct HealthAccessSettingsView: View {
-    @Environment(HealthKit.self) private var healthKit
-
-    @State private var isRequesting = false
+    @State private var requestingGroup: HealthPermissionGroup?
+    @State private var requestStates: [HealthPermissionGroup: HealthPermissionRequestState] = [:]
     @State private var errorMessage: String?
 
-    private var isAuthorized: Bool {
-        !ProcessInfo.processInfo.isPreviewSimulator && healthKit.isFullyAuthorized
-    }
+    private let healthService = HealthKitService.shared
 
     var body: some View {
         List {
             Section {
-                LabeledContent("Health Access", value: isAuthorized ? "Allowed" : "Not Allowed")
-
-                Button(isAuthorized ? "Review Health Access" : "Allow Health Access") {
-                    _Concurrency.Task { await requestAuthorization() }
+                ForEach(HealthPermissionGroup.allCases) { group in
+                    permissionRow(for: group)
                 }
-                .disabled(isRequesting)
             } footer: {
-                Text("iOS controls individual Health permissions. You can review the system prompt without restarting onboarding.")
+                Text("S2Y requests each category only when you choose it. Apple does not reveal whether read access was allowed or denied, so S2Y never labels a category as Allowed.")
             }
 
-            if isRequesting {
+            if requestingGroup != nil {
                 Section {
                     HStack(spacing: 12) {
                         ProgressView()
@@ -377,18 +371,66 @@ private struct HealthAccessSettingsView: View {
         .listStyle(.insetGrouped)
         .navigationTitle("Health Permissions")
         .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await refreshRequestStates()
+        }
+    }
+
+    private func permissionRow(for group: HealthPermissionGroup) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: group.systemImage)
+                .foregroundStyle(.red)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(group.title)
+                    .font(.headline)
+                Text(group.purpose)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            Button(buttonTitle(for: group)) {
+                _Concurrency.Task { await requestAuthorization(for: group) }
+            }
+            .buttonStyle(.bordered)
+            .disabled(requestingGroup != nil || requestStates[group] == .unavailable)
+            .accessibilityIdentifier("health-permission-\(group.rawValue)")
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func buttonTitle(for group: HealthPermissionGroup) -> String {
+        switch requestStates[group] {
+        case .requested:
+            "Requested"
+        case .unavailable:
+            "Unavailable"
+        case .review, .none:
+            "Review"
+        }
     }
 
     @MainActor
-    private func requestAuthorization() async {
-        isRequesting = true
+    private func requestAuthorization(for group: HealthPermissionGroup) async {
+        requestingGroup = group
         errorMessage = nil
-        defer { isRequesting = false }
+        defer { requestingGroup = nil }
 
         do {
-            try await healthKit.askForAuthorization()
+            try await healthService.requestAuthorization(for: [group])
+            requestStates[group] = await healthService.permissionRequestState(for: group)
         } catch {
             errorMessage = "Health access could not be updated: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func refreshRequestStates() async {
+        for group in HealthPermissionGroup.allCases {
+            requestStates[group] = await healthService.permissionRequestState(for: group)
         }
     }
 }

--- a/S2Y/Showcase/ShowcaseView.swift
+++ b/S2Y/Showcase/ShowcaseView.swift
@@ -354,6 +354,12 @@ private struct HealthAccessSettingsView: View {
                 } label: {
                     Label("Data Sources & Freshness", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
                 }
+
+                NavigationLink {
+                    ClinicalRecordsSettingsView()
+                } label: {
+                    Label("Clinical Records", systemImage: "cross.case")
+                }
             } footer: {
                 Text("S2Y requests each category only when you choose it. Apple does not reveal whether read access was allowed or denied, so S2Y never labels a category as Allowed.")
             }
@@ -437,6 +443,98 @@ private struct HealthAccessSettingsView: View {
     private func refreshRequestStates() async {
         for group in HealthPermissionGroup.allCases {
             requestStates[group] = await healthService.permissionRequestState(for: group)
+        }
+    }
+}
+
+private struct ClinicalRecordsSettingsView: View {
+    @State private var selectedCategories: Set<ClinicalRecordCategory> = []
+    @State private var records: [ClinicalRecordSummary] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    private let healthService = HealthKitService.shared
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(ClinicalRecordCategory.allCases) { category in
+                    Toggle(category.title, isOn: selectionBinding(for: category))
+                }
+
+                Button("Review Selected Access") {
+                    _Concurrency.Task { await requestAndLoadRecords() }
+                }
+                .disabled(selectedCategories.isEmpty || isLoading)
+            } footer: {
+                Text("Clinical records are read-only. Select only the record types you want S2Y to display, then review Apple's permission sheet.")
+            }
+
+            if isLoading {
+                Section {
+                    ProgressView("Reading selected records…")
+                }
+            } else if records.isEmpty, errorMessage == nil {
+                Section {
+                    Text("No selected clinical records are currently readable.")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section("Records") {
+                    ForEach(records) { record in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(record.displayName)
+                            Text("\(record.category.title) · \(record.sourceName)")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                            Text(record.recordedAt, format: .dateTime.year().month().day())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .accessibilityHint("Linked to the original Health clinical record")
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("Clinical Records")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func selectionBinding(for category: ClinicalRecordCategory) -> Binding<Bool> {
+        Binding(
+            get: { selectedCategories.contains(category) },
+            set: { selected in
+                if selected {
+                    selectedCategories.insert(category)
+                } else {
+                    selectedCategories.remove(category)
+                }
+            }
+        )
+    }
+
+    @MainActor
+    private func requestAndLoadRecords() async {
+        isLoading = true
+        records = []
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            try await healthService.requestClinicalRecordAuthorization(for: selectedCategories)
+            for category in ClinicalRecordCategory.allCases where selectedCategories.contains(category) {
+                records.append(contentsOf: try await healthService.fetchClinicalRecordSummaries(for: category))
+            }
+            records.sort { $0.recordedAt > $1.recordedAt }
+        } catch {
+            errorMessage = "Clinical records could not be read: \(error.localizedDescription)"
         }
     }
 }

--- a/S2Y/Supporting Files/Info.plist
+++ b/S2Y/Supporting Files/Info.plist
@@ -41,9 +41,9 @@
 	<key>NSCameraUsageDescription</key>
 	<string>This message should never appear. Please adjust this when you start using camera information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>S2Y uses the step count to demonstrate health data integration.</string>
+	<string>S2Y reads only the health categories you select to explain your personal activity, sleep, heart, vital, and body-measurement trends.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>S2Y uses the step count to demonstrate health data integration.</string>
+	<string>S2Y writes health data only when you explicitly use a supported connected-device feature.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/S2Y/Supporting Files/S2Y.entitlements
+++ b/S2Y/Supporting Files/S2Y.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.developer.healthkit.background-delivery</key>
 	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array>
+		<string>health-records</string>
+	</array>
 </dict>
 </plist>

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -262,4 +262,13 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(String(blocks[1].content.characters), "Average: 7.5 hours")
         XCTAssertFalse(blocks.map { String($0.content.characters) }.joined().contains("**"))
     }
+
+    func testHealthPermissionGroupsArePurposeBasedAndNonOverlapping() {
+        let groups = HealthPermissionGroup.allCases
+        let allMetrics = groups.flatMap(\.metricKinds)
+
+        XCTAssertEqual(Set(allMetrics), Set(HealthKitService.MetricKind.allCases))
+        XCTAssertEqual(allMetrics.count, Set(allMetrics).count)
+        XCTAssertTrue(groups.allSatisfy { !$0.title.isEmpty && !$0.purpose.isEmpty })
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -271,4 +271,21 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(allMetrics.count, Set(allMetrics).count)
         XCTAssertTrue(groups.allSatisfy { !$0.title.isEmpty && !$0.purpose.isEmpty })
     }
+
+    func testHealthMetricFreshnessUsesClearAgeBands() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+
+        XCTAssertEqual(
+            HealthMetricProvenance.freshness(for: now.addingTimeInterval(-24 * 60 * 60), relativeTo: now),
+            .current
+        )
+        XCTAssertEqual(
+            HealthMetricProvenance.freshness(for: now.addingTimeInterval(-4 * 24 * 60 * 60), relativeTo: now),
+            .aging
+        )
+        XCTAssertEqual(
+            HealthMetricProvenance.freshness(for: now.addingTimeInterval(-8 * 24 * 60 * 60), relativeTo: now),
+            .stale
+        )
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -288,4 +288,23 @@ final class OmerMobileChatModelsTests: XCTestCase {
             .stale
         )
     }
+
+    func testClinicalRecordSummaryRoundTripsWithoutRawFHIRPayload() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let summary = ClinicalRecordSummary(
+            id: id,
+            category: .labResults,
+            displayName: "Example laboratory result",
+            recordedAt: date,
+            sourceName: "Example Health Provider",
+            fhirResourceIdentifier: "Observation/example"
+        )
+
+        let data = try encoder.encode(summary)
+        let decoded = try decoder.decode(ClinicalRecordSummary.self, from: data)
+
+        XCTAssertEqual(decoded, summary)
+        XCTAssertFalse(String(decoding: data, as: UTF8.self).contains("resourceType"))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -307,4 +307,74 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(decoded, summary)
         XCTAssertFalse(String(decoding: data, as: UTF8.self).contains("resourceType"))
     }
+
+    func testWearableMeasurementsNormalizeUnitsAndPreserveOrigin() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let input = WearableMeasurementInput(
+            id: "energy-1",
+            metricIdentifier: "HKQuantityTypeIdentifierActiveEnergyBurned",
+            value: 418.4,
+            unit: "kJ",
+            startDate: date,
+            endDate: date.addingTimeInterval(60),
+            timeZoneIdentifier: "America/New_York",
+            sourceIdentifier: "com.example.watch",
+            sourceName: "Example Watch",
+            deviceName: "Watch"
+        )
+
+        let result = try XCTUnwrap(WearableMeasurementNormalizer.normalize([input]).first)
+
+        XCTAssertEqual(result.value, 100, accuracy: 0.001)
+        XCTAssertEqual(result.unit, "kcal")
+        XCTAssertEqual(result.originalValue, 418.4)
+        XCTAssertEqual(result.originalUnit, "kJ")
+        XCTAssertEqual(result.sourceIdentifier, "com.example.watch")
+        XCTAssertEqual(result.timeZoneIdentifier, "America/New_York")
+    }
+
+    func testWearableDeduplicationIsScopedToSourceAndSyncIdentifier() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        func sample(id: String, source: String, version: Int, value: Double) -> WearableMeasurementInput {
+            WearableMeasurementInput(
+                id: id,
+                metricIdentifier: "HKQuantityTypeIdentifierStepCount",
+                value: value,
+                unit: "count",
+                startDate: date,
+                endDate: date,
+                timeZoneIdentifier: "UTC",
+                sourceIdentifier: source,
+                sourceName: source,
+                syncIdentifier: "shared-sync-id",
+                syncVersion: version
+            )
+        }
+
+        let normalized = WearableMeasurementNormalizer.normalize([
+            sample(id: "old", source: "watch-a", version: 1, value: 10),
+            sample(id: "new", source: "watch-a", version: 2, value: 20),
+            sample(id: "other-source", source: "watch-b", version: 1, value: 30)
+        ])
+
+        XCTAssertEqual(normalized.count, 2)
+        XCTAssertEqual(Set(normalized.map(\.id)), ["new", "other-source"])
+    }
+
+    func testWearableNormalizerRejectsVendorOnlyScores() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let vendorScore = WearableMeasurementInput(
+            id: "score-1",
+            metricIdentifier: "com.vendor.readiness-score",
+            value: 92,
+            unit: "score",
+            startDate: date,
+            endDate: date,
+            timeZoneIdentifier: "UTC",
+            sourceIdentifier: "com.vendor.app",
+            sourceName: "Vendor"
+        )
+
+        XCTAssertTrue(WearableMeasurementNormalizer.normalize([vendorScore]).isEmpty)
+    }
 }


### PR DESCRIPTION
## Theme
Establish trustworthy, purpose-scoped health data connections for the Health Assistant.

## Stories
- HLT-005: Request HealthKit permissions by user-visible purpose instead of requesting everything on chat launch.
- HLT-006: Show the source, device, update time, and freshness of available health metrics.
- HLT-007: Add category-scoped, read-only clinical record authorization and safe summaries without retaining raw FHIR payloads.
- HLT-008: Normalize wearable units/time zones while preserving provenance and applying source-scoped deduplication.

## Safety and privacy
- Health data remains read-only.
- Clinical record access is separately requested by category.
- Vendor-only scores are rejected as unsupported rather than represented as raw HealthKit measurements.
- Cross-source measurements are not deduplicated together.

## Verification
- Generic iOS Simulator build passes locally with code signing disabled.
- All S2Y unit tests pass locally on iPhone 17 Pro simulator (iOS 26.2).
- Both GitHub Build and Test jobs pass.
- Entitlements plist validation passes.
- The local full-scheme UI runner previously stalled while materializing its simulator worker; GitHub's complete Build and Test jobs subsequently passed.

## Known repository-wide CI context
SwiftLint, REUSE, and Codecov failures are pre-existing repository configuration/debt and are not introduced by this theme.
