### PR TITLE
EPIC-H03: Add trustworthy health trends and charts

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -453,6 +453,8 @@ struct HealthAssistantView: View {
             for: query,
             includeHealthContext: omerIncludeHealthContext
         )
+        let chartAttachment = await HealthChatVisualizationLoader.load(for: query)
+        updateAssistantAttachment(id: assistantPlaceholder.id, attachment: chartAttachment)
 
         if selectedAIMode == .onDevice, appleModelService.availability.isAvailable {
             do {
@@ -576,7 +578,8 @@ struct HealthAssistantView: View {
         messages[index] = ChatMessage(
             id: id,
             role: existingMessage.role,
-            content: existingMessage.content + delta
+            content: existingMessage.content + delta,
+            chartAttachment: existingMessage.chartAttachment
         )
         streamTick += 1
     }
@@ -588,7 +591,28 @@ struct HealthAssistantView: View {
         }
 
         let existingMessage = messages[index]
-        messages[index] = ChatMessage(id: id, role: existingMessage.role, content: content)
+        messages[index] = ChatMessage(
+            id: id,
+            role: existingMessage.role,
+            content: content,
+            chartAttachment: existingMessage.chartAttachment
+        )
+        streamTick += 1
+    }
+
+    @MainActor
+    private func updateAssistantAttachment(id: UUID, attachment: HealthChartAttachment?) {
+        guard let attachment,
+              let index = messages.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let existingMessage = messages[index]
+        messages[index] = ChatMessage(
+            id: id,
+            role: existingMessage.role,
+            content: existingMessage.content,
+            chartAttachment: attachment
+        )
         streamTick += 1
     }
 
@@ -722,16 +746,23 @@ struct ChatMessage: Identifiable, Sendable {
     let id: UUID
     let role: Role
     let content: String
+    let chartAttachment: HealthChartAttachment?
     
     enum Role {
         case user
         case assistant
     }
 
-    init(id: UUID = UUID(), role: Role, content: String) {
+    init(
+        id: UUID = UUID(),
+        role: Role,
+        content: String,
+        chartAttachment: HealthChartAttachment? = nil
+    ) {
         self.id = id
         self.role = role
         self.content = content
+        self.chartAttachment = chartAttachment
     }
 }
 
@@ -869,11 +900,26 @@ struct MessageBubble: View {
                             .fill(message.role == .user ? Color.blue : Color.gray.opacity(0.2))
                     )
                     .foregroundColor(message.role == .user ? .white : .primary)
+
+                if let chartAttachment = message.chartAttachment {
+                    chart(attachment: chartAttachment)
+                        .accessibilityIdentifier("health-assistant-chart")
+                }
             }
             
             if message.role == .assistant {
                 Spacer(minLength: 60)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func chart(attachment: HealthChartAttachment) -> some View {
+        switch attachment {
+        case .trend(let trend, let kind):
+            HealthTrendChart(trend: trend, metricKind: kind)
+        case .comparison(let comparison, let kind):
+            HealthComparisonChart(comparison: comparison, metricKind: kind)
         }
     }
 

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -902,8 +902,13 @@ struct MessageBubble: View {
                     .foregroundColor(message.role == .user ? .white : .primary)
 
                 if let chartAttachment = message.chartAttachment {
-                    chart(attachment: chartAttachment)
-                        .accessibilityIdentifier("health-assistant-chart")
+                    VStack(alignment: .leading, spacing: 6) {
+                        chart(attachment: chartAttachment)
+                            .accessibilityIdentifier("health-assistant-chart")
+                        Label(HealthInterpretationPolicy.wellnessBoundary, systemImage: "info.circle")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             

--- a/S2Y/HealthAssistant/HealthChatVisualization.swift
+++ b/S2Y/HealthAssistant/HealthChatVisualization.swift
@@ -1,0 +1,55 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+enum HealthChartRequest: Equatable, Sendable {
+    case trend(kind: HealthKitService.MetricKind, days: Int)
+    case comparison(kind: HealthKitService.MetricKind, days: Int)
+
+    static func parse(_ query: String) -> HealthChartRequest? {
+        guard let intent = QueryPlanner.parse(query) else {
+            return nil
+        }
+        switch intent {
+        case .trend(let kind, let days):
+            return .trend(kind: kind, days: days)
+        case .compare(let kind, let windowDays):
+            return .comparison(kind: kind, days: windowDays)
+        }
+    }
+}
+
+enum HealthChartAttachment: Sendable {
+    case trend(HealthKitService.Trend, HealthKitService.MetricKind)
+    case comparison(HealthKitService.Comparison, HealthKitService.MetricKind)
+}
+
+enum HealthChatVisualizationLoader {
+    /// Loads only data that is already readable. It never triggers a permission prompt from chat.
+    @MainActor
+    static func load(for query: String) async -> HealthChartAttachment? {
+        guard let request = HealthChartRequest.parse(query) else {
+            return nil
+        }
+        do {
+            switch request {
+            case .trend(let kind, let days):
+                let trend = try await HealthKitService.shared.trend(kind: kind, days: days)
+                guard trend.dataQuality != .unavailable else { return nil }
+                return .trend(trend, kind)
+            case .comparison(let kind, let days):
+                let comparison = try await HealthKitService.shared.compare(kind: kind, windowDays: days)
+                guard comparison.dataQuality != .unavailable else { return nil }
+                return .comparison(comparison, kind)
+            }
+        } catch {
+            return nil
+        }
+    }
+}

--- a/S2Y/HealthAssistant/HealthInterpretationPolicy.swift
+++ b/S2Y/HealthAssistant/HealthInterpretationPolicy.swift
@@ -1,0 +1,65 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+enum HealthInterpretationPolicy {
+    static let wellnessBoundary = "Health trends are wellness information, not a diagnosis or treatment recommendation."
+
+    static func trendContext(
+        _ trend: HealthKitService.Trend,
+        kind: HealthKitService.MetricKind
+    ) -> String {
+        let change = trend.changeRate * 100
+        return [
+            "\(kind.displayName), \(trend.windowDays)-day average: \(kind.formatValue(trend.average)).",
+            "First-to-last observed change: \(change.formatted(.number.precision(.fractionLength(1))))%.",
+            coverageDescription(
+                quality: trend.dataQuality,
+                observedDays: trend.observedDays,
+                expectedDays: trend.expectedDays
+            ),
+            wellnessBoundary
+        ].joined(separator: " ")
+    }
+
+    static func comparisonContext(
+        _ comparison: HealthKitService.Comparison,
+        kind: HealthKitService.MetricKind
+    ) -> String {
+        let change = comparison.deltaRate * 100
+        return [
+            "\(kind.displayName), current \(comparison.currentWindowDays)-day average: \(kind.formatValue(comparison.currentAverage)); previous average: \(kind.formatValue(comparison.previousAverage)).",
+            "Descriptive change: \(change.formatted(.number.precision(.fractionLength(1))))%.",
+            "Coverage: current \(comparison.currentObservedDays)/\(comparison.currentWindowDays) days; previous \(comparison.previousObservedDays)/\(comparison.previousWindowDays) days.",
+            qualityCaution(comparison.dataQuality),
+            wellnessBoundary
+        ].joined(separator: " ")
+    }
+
+    static func coverageDescription(
+        quality: HealthKitService.DataQuality,
+        observedDays: Int,
+        expectedDays: Int
+    ) -> String {
+        "Coverage: \(observedDays)/\(expectedDays) days. \(qualityCaution(quality))"
+    }
+
+    private static func qualityCaution(_ quality: HealthKitService.DataQuality) -> String {
+        switch quality {
+        case .unavailable:
+            "There is not enough readable data to describe a trend."
+        case .limited:
+            "Coverage is limited, so avoid drawing a conclusion from this period."
+        case .sufficient:
+            "Coverage is sufficient for a descriptive trend, but gaps remain."
+        case .complete:
+            "Coverage is complete for this period."
+        }
+    }
+}

--- a/S2Y/HealthAssistant/HealthQueryProcessor.swift
+++ b/S2Y/HealthAssistant/HealthQueryProcessor.swift
@@ -52,8 +52,6 @@ enum HealthQueryProcessor {
     }
     
     private static func processStructuredQuery(_ intent: QueryPlanner.Intent) async throws -> QueryResult {
-        try await HealthKitService.shared.requestAuthorization()
-        
         switch intent {
         case let .trend(kind, days):
             let trend = try await HealthKitService.shared.trend(kind: kind, days: days, useCache: true)
@@ -72,8 +70,6 @@ enum HealthQueryProcessor {
     }
     
     private static func generateHealthInsights(_ query: String) async throws -> QueryResult {
-        try await HealthKitService.shared.requestAuthorization()
-        
         var insights: [HealthInsight] = []
         
         // Generate insights for different metrics

--- a/S2Y/HealthAssistant/HealthVisualization.swift
+++ b/S2Y/HealthAssistant/HealthVisualization.swift
@@ -13,219 +13,221 @@ import SwiftUI
 struct HealthTrendChart: View {
     let trend: HealthKitService.Trend
     let metricKind: HealthKitService.MetricKind
-    
+
     private var title: String {
-        metricTitle(kind: metricKind)
+        metricKind.displayName
     }
-    
+
     private var unit: String {
-        metricUnit(kind: metricKind)
+        metricKind.unit
     }
-    
+
+    private var observedPoints: [HealthKitService.DailyMetric] {
+        trend.points.filter(\.isObserved)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("\(title) - \(trend.windowDays) Day Trend")
-                    .font(.headline)
-                
-                HStack {
-                    Text("Average: \(String(format: "%.1f", trend.average)) \(unit)")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("\(title) · \(trend.windowDays) days")
+                        .font(.headline)
                     Spacer()
-                    
-                    HStack {
-                        Image(systemName: trend.changeRate >= 0 ? "arrow.up.right" : "arrow.down.right")
-                            .foregroundColor(trend.changeRate >= 0 ? .green : .red)
-                        Text("\(String(format: "%.1f", abs(trend.changeRate * 100)))%")
-                            .foregroundColor(trend.changeRate >= 0 ? .green : .red)
-                    }
+                    HealthDataQualityBadge(quality: trend.dataQuality)
+                }
+
+                Text("\(trend.observedDays) of \(trend.expectedDays) days include data")
                     .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack(alignment: .firstTextBaseline) {
+                    Text(metricKind.formatValue(trend.average))
+                        .font(.title3.weight(.semibold))
+                    Text("average")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Label(
+                        "\(abs(trend.changeRate * 100).formatted(.number.precision(.fractionLength(1))))%",
+                        systemImage: trend.changeRate >= 0 ? "arrow.up.right" : "arrow.down.right"
+                    )
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(
+                        "First to last observed value changed \(trend.changeRate >= 0 ? "up" : "down") by \(abs(trend.changeRate * 100).formatted(.number.precision(.fractionLength(1)))) percent"
+                    )
                 }
             }
-            
-            Chart {
-                ForEach(trend.points, id: \.date) { point in
-                    LineMark(
-                        x: .value("Date", point.date),
-                        y: .value(title, point.value)
-                    )
-                    .foregroundStyle(.blue)
-                    .lineStyle(StrokeStyle(lineWidth: 2))
-                    
-                    PointMark(
-                        x: .value("Date", point.date),
-                        y: .value(title, point.value)
-                    )
-                    .foregroundStyle(.blue)
-                    .symbolSize(30)
-                }
-                
-                // Average line
-                RuleMark(y: .value("Average", trend.average))
-                    .foregroundStyle(.orange)
-                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 5]))
-                    .annotation(position: .trailing, alignment: .leading) {
-                        Text("Avg")
-                            .font(.caption2)
-                            .foregroundColor(.orange)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 2)
-                            .background(Color.orange.opacity(0.1))
-                            .cornerRadius(4)
+
+            if observedPoints.isEmpty {
+                ContentUnavailableView(
+                    "No data in this period",
+                    systemImage: "chart.line.uptrend.xyaxis",
+                    description: Text("Connect or sync a health data source, then try again.")
+                )
+                .frame(maxWidth: .infinity, minHeight: 180)
+            } else {
+                Chart {
+                    ForEach(observedPoints, id: \.date) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value(title, point.value)
+                        )
+                        .foregroundStyle(.tint)
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+
+                        PointMark(
+                            x: .value("Date", point.date),
+                            y: .value(title, point.value)
+                        )
+                        .foregroundStyle(.tint)
+                        .symbolSize(24)
                     }
-            }
-            .frame(height: 200)
-            .chartXAxis {
-                AxisMarks(values: .stride(by: .day, count: max(1, trend.windowDays / 7))) { _ in
-                    AxisGridLine()
-                    AxisValueLabel(format: .dateTime.month().day())
+
+                    RuleMark(y: .value("Average", trend.average))
+                        .foregroundStyle(.secondary)
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
                 }
-            }
-            .chartYAxis {
-                AxisMarks { _ in
-                    AxisGridLine()
-                    AxisValueLabel()
+                .frame(height: 200)
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day, count: max(1, trend.windowDays / 6))) { _ in
+                        AxisGridLine()
+                        AxisValueLabel(format: .dateTime.month().day())
+                    }
                 }
+                .chartYAxis {
+                    AxisMarks { _ in
+                        AxisGridLine()
+                        AxisValueLabel()
+                    }
+                }
+                .accessibilityLabel("\(title), \(trend.windowDays)-day trend chart")
+                .accessibilityValue(
+                    "Average \(trend.average.formatted(.number.precision(.fractionLength(1)))) \(unit), based on \(trend.observedDays) observed days"
+                )
+            }
+
+            if trend.dataQuality == .limited {
+                Label(
+                    "Treat this trend cautiously because fewer than half of the days contain data.",
+                    systemImage: "exclamationmark.circle"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
         }
         .padding()
-        .background(Color.gray.opacity(0.05))
-        .cornerRadius(12)
-    }
-    
-    private func metricUnit(kind: HealthKitService.MetricKind) -> String {
-        return HealthMetricsDictionary.unit(for: kind)
-    }
-    
-    private func metricTitle(kind: HealthKitService.MetricKind) -> String {
-        return HealthMetricsDictionary.displayName(for: kind)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }
 
 struct HealthComparisonChart: View {
     let comparison: HealthKitService.Comparison
     let metricKind: HealthKitService.MetricKind
-    
-    private var title: String {
-        metricTitle(kind: metricKind)
+
+    private struct PeriodAverage: Identifiable {
+        let id: String
+        let title: String
+        let value: Double
     }
-    
-    private var unit: String {
-        metricUnit(kind: metricKind)
+
+    private var periodAverages: [PeriodAverage] {
+        [
+            PeriodAverage(id: "previous", title: "Previous", value: comparison.previousAverage),
+            PeriodAverage(id: "current", title: "Current", value: comparison.currentAverage)
+        ]
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("\(title) - Comparison Analysis")
+            HStack(alignment: .firstTextBaseline) {
+                Text("\(metricKind.displayName) comparison")
                     .font(.headline)
-                
-                Text("\(comparison.currentWindowDays) Day Window Comparison")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-            
-            HStack(spacing: 20) {
-                // Bar Chart
-                HStack(spacing: 12) {
-                    VStack {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(.blue.opacity(0.7))
-                            .frame(width: 40, height: max(20, CGFloat(comparison.previousAverage / max(comparison.currentAverage, comparison.previousAverage, 1) * 120)))
-                        Text("Previous")
-                            .font(.caption2)
-                    }
-                    
-                    VStack {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(.blue)
-                            .frame(width: 40, height: max(20, CGFloat(comparison.currentAverage / max(comparison.currentAverage, comparison.previousAverage, 1) * 120)))
-                        Text("Current")
-                            .font(.caption2)
-                    }
-                }
-                
                 Spacer()
-                
-                // Statistics
-                VStack(alignment: .trailing, spacing: 8) {
-                    HStack {
-                        Text("Current Avg:")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Text("\(String(format: "%.1f", comparison.currentAverage)) \(unit)")
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                    }
-                    
-                    HStack {
-                        Text("Previous Avg:")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Text("\(String(format: "%.1f", comparison.previousAverage)) \(unit)")
-                            .font(.caption)
-                    }
-                    
-                    Divider()
-                        .frame(width: 80)
-                    
-                    HStack {
-                        Text("Change:")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        HStack {
-                            Image(systemName: comparison.delta >= 0 ? "arrow.up" : "arrow.down")
-                                .font(.caption2)
-                            Text("\(String(format: "%.1f", abs(comparison.deltaRate * 100)))%")
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                        }
-                        .foregroundColor(comparison.delta >= 0 ? .green : .red)
-                    }
+                HealthDataQualityBadge(quality: comparison.dataQuality)
+            }
+
+            Text("Two adjacent \(comparison.currentWindowDays)-day periods")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Chart(periodAverages) { period in
+                BarMark(
+                    x: .value("Period", period.title),
+                    y: .value(metricKind.displayName, period.value)
+                )
+                .foregroundStyle(period.id == "current" ? Color.accentColor : Color.secondary.opacity(0.55))
+                .annotation(position: .top) {
+                    Text(metricKind.formatValue(period.value))
+                        .font(.caption2.weight(.medium))
                 }
             }
-            
-            // Interpretation
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Analysis")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.secondary)
-                
+            .frame(height: 180)
+            .accessibilityLabel("\(metricKind.displayName), period comparison chart")
+            .accessibilityValue(
+                "Current average \(metricKind.formatValue(comparison.currentAverage)); previous average \(metricKind.formatValue(comparison.previousAverage))"
+            )
+
+            Label {
                 Text(interpretComparison())
-                    .font(.caption)
-                    .foregroundColor(.primary)
+            } icon: {
+                Image(systemName: comparison.delta >= 0 ? "arrow.up.right" : "arrow.down.right")
             }
-            .padding(.top, 8)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            Text(
+                "Current: \(comparison.currentObservedDays)/\(comparison.currentWindowDays) days · Previous: \(comparison.previousObservedDays)/\(comparison.previousWindowDays) days"
+            )
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+
+            if comparison.dataQuality == .limited {
+                Label(
+                    "This comparison has limited coverage in at least one period.",
+                    systemImage: "exclamationmark.circle"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
         }
         .padding()
-        .background(Color.gray.opacity(0.05))
-        .cornerRadius(12)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
-    
+
     private func interpretComparison() -> String {
         let change = abs(comparison.deltaRate * 100)
-        let direction = comparison.delta >= 0 ? "increase" : "decrease"
-        
+        let direction = comparison.delta >= 0 ? "higher" : "lower"
+
         if change < 5 {
-            return "Data remains relatively stable with minimal changes."
-        } else if change < 15 {
-            return "Shows a \(direction) of \(String(format: "%.1f", change))%, indicating minor changes."
-        } else if change < 30 {
-            return "Shows a \(direction) of \(String(format: "%.1f", change))%, indicating noticeable changes."
-        } else {
-            return "Shows a \(direction) of \(String(format: "%.1f", change))%, indicating significant changes that warrant attention."
+            return "The two period averages are similar."
+        }
+        return "The current average is \(change.formatted(.number.precision(.fractionLength(1))))% \(direction) than the previous period. This describes a change, not whether it is medically good or bad."
+    }
+}
+
+private struct HealthDataQualityBadge: View {
+    let quality: HealthKitService.DataQuality
+
+    private var title: String {
+        switch quality {
+        case .unavailable: "No data"
+        case .limited: "Limited"
+        case .sufficient: "Good coverage"
+        case .complete: "Complete"
         }
     }
-    
-    private func metricUnit(kind: HealthKitService.MetricKind) -> String {
-        return HealthMetricsDictionary.unit(for: kind)
-    }
-    
-    private func metricTitle(kind: HealthKitService.MetricKind) -> String {
-        return HealthMetricsDictionary.displayName(for: kind)
+
+    var body: some View {
+        Text(title)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.thinMaterial, in: Capsule())
+            .accessibilityLabel("Data coverage: \(title)")
     }
 }
 

--- a/S2Y/HealthKit/HealthKitService.swift
+++ b/S2Y/HealthKit/HealthKitService.swift
@@ -280,6 +280,13 @@ public final class HealthKitService {
     public struct DailyMetric: Sendable, Codable {
         public let date: Date
         public let value: Double
+        public let isObserved: Bool
+
+        public init(date: Date, value: Double, isObserved: Bool = true) {
+            self.date = date
+            self.value = value
+            self.isObserved = isObserved
+        }
     }
 
     public enum MetricKind: Sendable, Codable, CaseIterable, Hashable {
@@ -391,7 +398,7 @@ public final class HealthKitService {
                                 quantity = nil
                             }
                             let value = quantity?.doubleValue(for: quantityDescriptor.unit) ?? 0
-                            output.append(.init(date: date, value: value))
+                            output.append(.init(date: date, value: value, isObserved: quantity != nil))
                         }
                         cont.resume(returning: output)
                     }
@@ -513,11 +520,61 @@ public final class HealthKitService {
 
     // MARK: - Aggregations
 
+    public enum DataQuality: String, Sendable, Codable {
+        case unavailable
+        case limited
+        case sufficient
+        case complete
+
+        public static func classify(observedDays: Int, expectedDays: Int) -> DataQuality {
+            guard observedDays > 0, expectedDays > 0 else {
+                return .unavailable
+            }
+            let coverage = Double(observedDays) / Double(expectedDays)
+            if coverage >= 0.9 {
+                return .complete
+            }
+            if coverage >= 0.5 {
+                return .sufficient
+            }
+            return .limited
+        }
+    }
+
     public struct Trend: Sendable, Codable {
         public let windowDays: Int
         public let points: [DailyMetric]
         public let average: Double
         public let changeRate: Double // last vs first
+        public let observedDays: Int
+        public let expectedDays: Int
+        public let dataQuality: DataQuality
+
+        public var coverageRate: Double {
+            guard expectedDays > 0 else { return 0 }
+            return Double(observedDays) / Double(expectedDays)
+        }
+
+        static func summarize(windowDays: Int, points: [DailyMetric]) -> Trend {
+            let observed = points.filter(\.isObserved)
+            let values = observed.map(\.value)
+            let average = values.average()
+            let changeRate: Double
+            if let first = values.first, let last = values.last, abs(first) > 1e-9 {
+                changeRate = (last - first) / abs(first)
+            } else {
+                changeRate = 0
+            }
+            return Trend(
+                windowDays: windowDays,
+                points: points,
+                average: average,
+                changeRate: changeRate,
+                observedDays: observed.count,
+                expectedDays: windowDays,
+                dataQuality: .classify(observedDays: observed.count, expectedDays: windowDays)
+            )
+        }
     }
 
     public func trend(kind: MetricKind, days: Int, endingAt end: Date = Date(), useCache: Bool = true) async throws -> Trend {
@@ -533,12 +590,7 @@ public final class HealthKitService {
         let calendar = Calendar.current
         let start = calendar.date(byAdding: .day, value: -days + 1, to: calendar.startOfDay(for: end)) ?? end
         let series = try await fetchDailyMetrics(kind: kind, start: start, end: end, useCache: useCache)
-        let values = series.map { $0.value }
-        let avg = values.isEmpty ? 0 : values.reduce(0, +) / Double(values.count)
-        let change = (values.last ?? 0) - (values.first ?? 0)
-        let base = max(1e-9, abs(values.first ?? 0))
-        let changeRate = change / base
-        let result = Trend(windowDays: days, points: series, average: avg, changeRate: changeRate)
+        let result = Trend.summarize(windowDays: days, points: series)
         
         // Cache the result
         if useCache {
@@ -556,6 +608,34 @@ public final class HealthKitService {
         public let previousAverage: Double
         public let delta: Double
         public let deltaRate: Double
+        public let currentObservedDays: Int
+        public let previousObservedDays: Int
+        public let dataQuality: DataQuality
+
+        static func summarize(
+            windowDays: Int,
+            current: [DailyMetric],
+            previous: [DailyMetric]
+        ) -> Comparison {
+            let currentValues = current.filter(\.isObserved).map(\.value)
+            let previousValues = previous.filter(\.isObserved).map(\.value)
+            let currentAverage = currentValues.average()
+            let previousAverage = previousValues.average()
+            let delta = currentAverage - previousAverage
+            let deltaRate = abs(previousAverage) > 1e-9 ? delta / abs(previousAverage) : 0
+            let observedDays = min(currentValues.count, previousValues.count)
+            return Comparison(
+                currentWindowDays: windowDays,
+                previousWindowDays: windowDays,
+                currentAverage: currentAverage,
+                previousAverage: previousAverage,
+                delta: delta,
+                deltaRate: deltaRate,
+                currentObservedDays: currentValues.count,
+                previousObservedDays: previousValues.count,
+                dataQuality: .classify(observedDays: observedDays, expectedDays: windowDays)
+            )
+        }
     }
 
     public func compare(kind: MetricKind, windowDays: Int, endingAt end: Date = Date(), useCache: Bool = true) async throws -> Comparison {
@@ -578,18 +658,10 @@ public final class HealthKitService {
         async let previous = fetchDailyMetrics(kind: kind, start: startPrev, end: endPrev, useCache: useCache)
 
         let (curSeries, prevSeries) = try await (current, previous)
-        let curAvg = curSeries.map { $0.value }.average()
-        let prevAvg = prevSeries.map { $0.value }.average()
-        let delta = curAvg - prevAvg
-        let base = max(1e-9, abs(prevAvg))
-        let deltaRate = delta / base
-        let result = Comparison(
-            currentWindowDays: windowDays,
-            previousWindowDays: windowDays,
-            currentAverage: curAvg,
-            previousAverage: prevAvg,
-            delta: delta,
-            deltaRate: deltaRate
+        let result = Comparison.summarize(
+            windowDays: windowDays,
+            current: curSeries,
+            previous: prevSeries
         )
         
         // Cache the result
@@ -620,6 +692,7 @@ public final class HealthKitService {
 
         let calendar = Calendar.current
         var dayBuckets: [Date: TimeInterval] = [:]
+        var observedDays: Set<Date> = []
         var cur = calendar.startOfDay(for: start)
         let endDay = calendar.startOfDay(for: end)
         while cur <= endDay {
@@ -650,12 +723,17 @@ public final class HealthKitService {
                 let intervalEnd = min(dayEnd, segEnd)
                 let overlap = intervalEnd.timeIntervalSince(segStart)
                 dayBuckets[dayStart, default: 0] += max(0, overlap)
+                observedDays.insert(dayStart)
                 segStart = intervalEnd
             }
         }
 
         return dayBuckets.keys.sorted().map { day in
-            .init(date: day, value: dayBuckets[day, default: 0] / 3600.0)
+            .init(
+                date: day,
+                value: dayBuckets[day, default: 0] / 3600.0,
+                isObserved: observedDays.contains(day)
+            )
         }
     }
 }

--- a/S2Y/LLM/EnhancedQueryPlanner.swift
+++ b/S2Y/LLM/EnhancedQueryPlanner.swift
@@ -89,8 +89,6 @@ enum EnhancedQueryPlanner {
     }
     
     static func run(intent: Intent) async throws -> HealthQueryProcessor.QueryResult {
-        try await HealthKitService.shared.requestAuthorization()
-        
         switch intent {
         case let .compare(kind, windowDays):
             let comparison = try await HealthKitService.shared.compare(

--- a/S2Y/LLM/Omer/OmerHealthContextBuilder.swift
+++ b/S2Y/LLM/Omer/OmerHealthContextBuilder.swift
@@ -30,12 +30,13 @@ enum OmerHealthContextBuilder {
                     return (key, String(normalized.prefix(200)))
                 }
         )
+        context["interpretationBoundary"] = HealthInterpretationPolicy.wellnessBoundary
 
         do {
             let result = try await HealthQueryProcessor.processQuery(query)
             let queryResult = format(result).trimmingCharacters(in: .whitespacesAndNewlines)
             if !queryResult.isEmpty {
-                context["queryResult"] = String(queryResult.prefix(200))
+                context["queryResult"] = String(queryResult.prefix(500))
             }
         } catch {
             // Health data can be unavailable or partially authorized. Existing context,
@@ -50,11 +51,9 @@ enum OmerHealthContextBuilder {
         case .textResponse(let text):
             return text
         case .trend(let trend, let kind):
-            let change = trend.changeRate * 100
-            return "\(kind.displayName), \(trend.windowDays)-day average: \(kind.formatValue(trend.average)); first-to-last change: \(change.formatted(.number.precision(.fractionLength(1))))%."
+            return HealthInterpretationPolicy.trendContext(trend, kind: kind)
         case .comparison(let comparison, let kind):
-            let change = comparison.deltaRate * 100
-            return "\(kind.displayName), current \(comparison.currentWindowDays)-day average: \(kind.formatValue(comparison.currentAverage)); previous average: \(kind.formatValue(comparison.previousAverage)); change: \(change.formatted(.number.precision(.fractionLength(1))))%."
+            return HealthInterpretationPolicy.comparisonContext(comparison, kind: kind)
         case .insights(let insights):
             return insights.map { insight in
                 var parts = [insight.title, insight.insight]

--- a/S2Y/LLM/QueryPlanner.swift
+++ b/S2Y/LLM/QueryPlanner.swift
@@ -73,8 +73,6 @@ enum QueryPlanner {
     }
 
     static func run(intent: Intent) async throws -> String {
-        try await HealthKitService.shared.requestAuthorization()
-
         switch intent {
         case let .compare(kind, windowDays):
             let comparison = try await HealthKitService.shared.compare(
@@ -129,5 +127,4 @@ enum QueryPlanner {
         return "\(title)\n窗口平均：\(String(format: "%.2f", avg)) \(unit)\n首末变化：\(arrow) \(String(format: "%.1f", abs(rate)))%\n建议：保持良好习惯，必要时逐步调整计划。"
     }
 }
-
 

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -437,4 +437,21 @@ final class OmerMobileChatModelsTests: XCTestCase {
         )
         XCTAssertNil(HealthChartRequest.parse("What can I do to relax today?"))
     }
+
+    func testHealthInterpretationStatesCoverageAndWellnessBoundary() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T00:00:00Z"))
+        let trend = HealthKitService.Trend.summarize(
+            windowDays: 7,
+            points: [
+                .init(date: date, value: 6, isObserved: true),
+                .init(date: date.addingTimeInterval(86_400), value: 7, isObserved: true)
+            ]
+        )
+
+        let context = HealthInterpretationPolicy.trendContext(trend, kind: .sleepDurationHours)
+
+        XCTAssertTrue(context.contains("Coverage: 2/7 days"))
+        XCTAssertTrue(context.contains("Coverage is limited"))
+        XCTAssertTrue(context.contains("not a diagnosis or treatment recommendation"))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -425,4 +425,16 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(comparison.deltaRate, 1)
         XCTAssertEqual(comparison.dataQuality, .limited)
     }
+
+    func testHealthChartRequestRecognizesTrendAndComparisonWindows() {
+        XCTAssertEqual(
+            HealthChartRequest.parse("How have my steps trended over the past 30 days?"),
+            .trend(kind: .steps, days: 30)
+        )
+        XCTAssertEqual(
+            HealthChartRequest.parse("Compare my heart rate this week vs last week"),
+            .comparison(kind: .heartRateAverage, days: 7)
+        )
+        XCTAssertNil(HealthChartRequest.parse("What can I do to relax today?"))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -377,4 +377,52 @@ final class OmerMobileChatModelsTests: XCTestCase {
 
         XCTAssertTrue(WearableMeasurementNormalizer.normalize([vendorScore]).isEmpty)
     }
+
+    func testTrendSummaryExcludesMissingDaysFromAverage() throws {
+        let start = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T00:00:00Z"))
+        var points: [HealthKitService.DailyMetric] = []
+        for offset in 0..<7 {
+            points.append(HealthKitService.DailyMetric(
+                date: start.addingTimeInterval(Double(offset) * 86_400),
+                value: offset < 2 ? Double((offset + 1) * 1_000) : 0,
+                isObserved: offset < 2
+            ))
+        }
+
+        let trend = HealthKitService.Trend.summarize(windowDays: 7, points: points)
+
+        XCTAssertEqual(trend.average, 1_500)
+        XCTAssertEqual(trend.changeRate, 1)
+        XCTAssertEqual(trend.observedDays, 2)
+        XCTAssertEqual(trend.dataQuality, .limited)
+    }
+
+    func testComparisonRequiresCoverageInBothWindows() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T00:00:00Z"))
+        var current: [HealthKitService.DailyMetric] = []
+        var previous: [HealthKitService.DailyMetric] = []
+        for offset in 0..<7 {
+            current.append(HealthKitService.DailyMetric(
+                date: date.addingTimeInterval(Double(offset) * 86_400),
+                value: 8_000,
+                isObserved: true
+            ))
+            previous.append(HealthKitService.DailyMetric(
+                date: date.addingTimeInterval(Double(offset - 7) * 86_400),
+                value: offset < 2 ? 4_000 : 0,
+                isObserved: offset < 2
+            ))
+        }
+
+        let comparison = HealthKitService.Comparison.summarize(
+            windowDays: 7,
+            current: current,
+            previous: previous
+        )
+
+        XCTAssertEqual(comparison.currentAverage, 8_000)
+        XCTAssertEqual(comparison.previousAverage, 4_000)
+        XCTAssertEqual(comparison.deltaRate, 1)
+        XCTAssertEqual(comparison.dataQuality, .limited)
+    }
 }


### PR DESCRIPTION
## Theme
Turn readable Health data into transparent 7/30-day trends and comparisons, then present them as native charts in the active Health Assistant chat.

## Stories
- HLT-009: Distinguish missing days from observed zero values and calculate coverage-aware trend/comparison summaries.
- HLT-010: Present accessible native trend and period-comparison charts with neutral change language and visible data quality.
- HLT-011: Attach structured charts to current Health Assistant responses without triggering permission prompts from chat.
- HLT-012: Add data-quality cautions and a wellness-only interpretation boundary to local/Omer health context.

## Safety and privacy
- Chat queries read only already-authorized Health data and do not request all Health permissions.
- Missing data is not silently converted into observed zero values.
- Higher/lower values are described neutrally rather than labeled healthy/unhealthy.
- Generated context states that trends are wellness information, not diagnosis or treatment guidance.

## Verification
- Generic iOS Simulator build passes.
- Build-for-testing passes for app, unit-test, and UI-test targets.
- All S2Y unit tests pass on iPhone 16e simulator (iOS 26.2).
- Health Assistant UI smoke test runs through provider selection, keyboard dismissal, and drawer opening; its existing empty-history section-label assertion fails on a clean simulator account.

## Related roadmap
Advances #8 and #18.

## Scope note
The untracked BrandAssets directory remains excluded.