### PR TITLE
EPIC-H04: Add personal longitudinal health insights

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -925,6 +925,8 @@ struct MessageBubble: View {
             HealthTrendChart(trend: trend, metricKind: kind)
         case .comparison(let comparison, let kind):
             HealthComparisonChart(comparison: comparison, metricKind: kind)
+        case .personalInsights(let report):
+            PersonalHealthInsightCard(report: report)
         }
     }
 

--- a/S2Y/HealthAssistant/HealthChatVisualization.swift
+++ b/S2Y/HealthAssistant/HealthChatVisualization.swift
@@ -28,12 +28,16 @@ enum HealthChartRequest: Equatable, Sendable {
 enum HealthChartAttachment: Sendable {
     case trend(HealthKitService.Trend, HealthKitService.MetricKind)
     case comparison(HealthKitService.Comparison, HealthKitService.MetricKind)
+    case personalInsights(PersonalHealthInsightReport)
 }
 
 enum HealthChatVisualizationLoader {
     /// Loads only data that is already readable. It never triggers a permission prompt from chat.
     @MainActor
     static func load(for query: String) async -> HealthChartAttachment? {
+        if let report = await PersonalHealthInsightLoader.load(for: query) {
+            return .personalInsights(report)
+        }
         guard let request = HealthChartRequest.parse(query) else {
             return nil
         }

--- a/S2Y/HealthAssistant/HealthVisualization.swift
+++ b/S2Y/HealthAssistant/HealthVisualization.swift
@@ -231,6 +231,79 @@ private struct HealthDataQualityBadge: View {
     }
 }
 
+struct PersonalHealthInsightCard: View {
+    let report: PersonalHealthInsightReport
+
+    private var notableDeviations: [PersonalMetricDeviation] {
+        report.deviations.filter { $0.direction != .undetermined }
+    }
+
+    private var availableRelationships: [DescriptiveHealthRelationship] {
+        report.relationships.filter { $0.availability == .available }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Your recent patterns", systemImage: "sparkles")
+                .font(.headline)
+
+            Text("Based on observed days from the last \(report.windowDays) days")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(notableDeviations, id: \.metricKind) { deviation in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(deviation.metricKind.displayName)
+                        .font(.subheadline.weight(.semibold))
+                    Text(deviationText(deviation))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            ForEach(availableRelationships.indices, id: \.self) { index in
+                Text(availableRelationships[index].explanation)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !report.hasUsableInsight {
+                Text("More overlapping days are needed before S2Y can describe a personal pattern.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            Text(coverageText)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding()
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityLabel("Personal health insight summary")
+    }
+
+    private var coverageText: String {
+        report.coverage.map { coverage in
+            "\(coverage.metricKind.displayName): \(coverage.observedDays)/\(coverage.expectedDays) days"
+        }.joined(separator: " · ")
+    }
+
+    private func deviationText(_ deviation: PersonalMetricDeviation) -> String {
+        switch deviation.direction {
+        case .lower:
+            "Recent values are lower than your own earlier baseline."
+        case .higher:
+            "Recent values are higher than your own earlier baseline."
+        case .typical:
+            "Recent values are within your typical personal range."
+        case .undetermined:
+            "There is not enough data to compare with your personal baseline."
+        }
+    }
+}
+
 struct HealthMetricCard: View {
     let title: String
     let value: String

--- a/S2Y/HealthAssistant/PersonalHealthInsights.swift
+++ b/S2Y/HealthAssistant/PersonalHealthInsights.swift
@@ -1,0 +1,106 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+struct PersonalHealthInsightReport: Sendable {
+    let windowDays: Int
+    let generatedAt: Date
+    let coverage: [LongitudinalMetricCoverage]
+    let deviations: [PersonalMetricDeviation]
+    let relationships: [DescriptiveHealthRelationship]
+
+    var hasUsableInsight: Bool {
+        deviations.contains { $0.direction != .undetermined }
+            || relationships.contains { $0.availability == .available }
+    }
+}
+
+enum PersonalHealthInsightBuilder {
+    static func build(
+        dataset: LongitudinalHealthDataset,
+        generatedAt: Date = .now
+    ) -> PersonalHealthInsightReport {
+        let metricKinds = dataset.coverage.map(\.metricKind)
+        let deviations = metricKinds.map { metricKind in
+            let values = dataset.values(for: metricKind).map(\.value)
+            let currentCount = min(7, values.count)
+            let current = Array(values.suffix(currentCount))
+            let baseline = Array(values.dropLast(currentCount))
+            return PersonalHealthBaselineAnalyzer.deviation(
+                baselineValues: baseline,
+                currentValues: current,
+                metricKind: metricKind
+            )
+        }
+
+        let relationshipPairs: [(HealthKitService.MetricKind, HealthKitService.MetricKind)] = [
+            (.steps, .sleepDurationHours),
+            (.steps, .restingHeartRate),
+            (.sleepDurationHours, .restingHeartRate),
+            (.steps, .activeEnergy)
+        ]
+        let availableKinds = Set(metricKinds)
+        var relationships: [DescriptiveHealthRelationship] = []
+        for (first, second) in relationshipPairs
+            where availableKinds.contains(first) && availableKinds.contains(second) {
+            relationships.append(DescriptiveHealthRelationshipAnalyzer.analyze(
+                dataset: dataset,
+                first: first,
+                second: second
+            ))
+        }
+
+        return PersonalHealthInsightReport(
+            windowDays: dataset.expectedDays,
+            generatedAt: generatedAt,
+            coverage: dataset.coverage,
+            deviations: deviations,
+            relationships: relationships
+        )
+    }
+}
+
+enum PersonalHealthInsightLoader {
+    private static let supportedMetrics: [HealthKitService.MetricKind] = [
+        .steps,
+        .sleepDurationHours,
+        .restingHeartRate,
+        .activeEnergy
+    ]
+
+    static func matches(_ query: String) -> Bool {
+        let lowered = query.lowercased()
+        return ["insight", "pattern", "correlation", "relationship", "洞察", "模式", "关联"]
+            .contains { lowered.contains($0) }
+    }
+
+    @MainActor
+    static func load(for query: String, endingAt end: Date = .now) async -> PersonalHealthInsightReport? {
+        guard matches(query) else { return nil }
+        let calendar = Calendar.current
+        let start = calendar.date(byAdding: .day, value: -29, to: calendar.startOfDay(for: end)) ?? end
+        var series: [HealthKitService.MetricKind: [HealthKitService.DailyMetric]] = [:]
+        for metricKind in supportedMetrics {
+            if let points = try? await HealthKitService.shared.fetchDailyMetrics(
+                kind: metricKind,
+                start: start,
+                end: end
+            ), points.contains(where: \.isObserved) {
+                series[metricKind] = points
+            }
+        }
+        guard !series.isEmpty else { return nil }
+        let dataset = LongitudinalHealthAligner.align(
+            series: series,
+            expectedDays: 30,
+            calendar: calendar
+        )
+        return PersonalHealthInsightBuilder.build(dataset: dataset)
+    }
+}

--- a/S2Y/HealthKit/DescriptiveHealthRelationship.swift
+++ b/S2Y/HealthKit/DescriptiveHealthRelationship.swift
@@ -1,0 +1,150 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public struct DescriptiveHealthRelationship: Sendable, Equatable {
+    public enum Availability: String, Sendable, Equatable {
+        case insufficientData
+        case available
+    }
+
+    public enum Direction: String, Sendable, Equatable {
+        case movesTogether
+        case movesOppositely
+        case noClearPattern
+        case undetermined
+    }
+
+    public enum Strength: String, Sendable, Equatable {
+        case weak
+        case moderate
+        case strong
+        case undetermined
+    }
+
+    public let firstMetric: HealthKitService.MetricKind
+    public let secondMetric: HealthKitService.MetricKind
+    public let pairedDays: Int
+    public let availability: Availability
+    public let coefficient: Double?
+    public let direction: Direction
+    public let strength: Strength
+
+    public var explanation: String {
+        guard availability == .available else {
+            return "There are not enough days where both metrics were observed to describe a relationship."
+        }
+        let pattern: String
+        switch direction {
+        case .movesTogether:
+            pattern = "often moved in the same direction"
+        case .movesOppositely:
+            pattern = "often moved in opposite directions"
+        case .noClearPattern:
+            pattern = "did not show a clear linear pattern"
+        case .undetermined:
+            pattern = "could not be evaluated"
+        }
+        return "Across \(pairedDays) paired days, \(firstMetric.displayName) and \(secondMetric.displayName) \(pattern). This is a descriptive association, not evidence that one caused the other."
+    }
+}
+
+public enum DescriptiveHealthRelationshipAnalyzer {
+    public static let minimumPairedDays = 7
+
+    public static func analyze(
+        dataset: LongitudinalHealthDataset,
+        first: HealthKitService.MetricKind,
+        second: HealthKitService.MetricKind
+    ) -> DescriptiveHealthRelationship {
+        let pairs = dataset.pairedValues(first, second)
+        guard pairs.count >= minimumPairedDays else {
+            return unavailable(first: first, second: second, pairedDays: pairs.count)
+        }
+
+        let firstValues = pairs.map(\.first)
+        let secondValues = pairs.map(\.second)
+        guard let coefficient = pearson(firstValues, secondValues) else {
+            return DescriptiveHealthRelationship(
+                firstMetric: first,
+                secondMetric: second,
+                pairedDays: pairs.count,
+                availability: .available,
+                coefficient: 0,
+                direction: .noClearPattern,
+                strength: .weak
+            )
+        }
+
+        let magnitude = abs(coefficient)
+        let strength: DescriptiveHealthRelationship.Strength
+        if magnitude >= 0.7 {
+            strength = .strong
+        } else if magnitude >= 0.4 {
+            strength = .moderate
+        } else {
+            strength = .weak
+        }
+
+        let direction: DescriptiveHealthRelationship.Direction
+        if magnitude < 0.2 {
+            direction = .noClearPattern
+        } else if coefficient > 0 {
+            direction = .movesTogether
+        } else {
+            direction = .movesOppositely
+        }
+
+        return DescriptiveHealthRelationship(
+            firstMetric: first,
+            secondMetric: second,
+            pairedDays: pairs.count,
+            availability: .available,
+            coefficient: coefficient,
+            direction: direction,
+            strength: strength
+        )
+    }
+
+    private static func unavailable(
+        first: HealthKitService.MetricKind,
+        second: HealthKitService.MetricKind,
+        pairedDays: Int
+    ) -> DescriptiveHealthRelationship {
+        DescriptiveHealthRelationship(
+            firstMetric: first,
+            secondMetric: second,
+            pairedDays: pairedDays,
+            availability: .insufficientData,
+            coefficient: nil,
+            direction: .undetermined,
+            strength: .undetermined
+        )
+    }
+
+    private static func pearson(_ first: [Double], _ second: [Double]) -> Double? {
+        guard first.count == second.count, !first.isEmpty else { return nil }
+        let count = Double(first.count)
+        let firstMean = first.reduce(0, +) / count
+        let secondMean = second.reduce(0, +) / count
+        var numerator = 0.0
+        var firstSquared = 0.0
+        var secondSquared = 0.0
+        for index in first.indices {
+            let firstDelta = first[index] - firstMean
+            let secondDelta = second[index] - secondMean
+            numerator += firstDelta * secondDelta
+            firstSquared += firstDelta * firstDelta
+            secondSquared += secondDelta * secondDelta
+        }
+        let denominator = sqrt(firstSquared * secondSquared)
+        guard denominator > 1e-9 else { return nil }
+        return min(1, max(-1, numerator / denominator))
+    }
+}

--- a/S2Y/HealthKit/LongitudinalHealthDataset.swift
+++ b/S2Y/HealthKit/LongitudinalHealthDataset.swift
@@ -1,0 +1,105 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public struct LongitudinalMetricCoverage: Sendable, Equatable {
+    public let metricKind: HealthKitService.MetricKind
+    public let observedDays: Int
+    public let expectedDays: Int
+    public let dataQuality: HealthKitService.DataQuality
+
+    public var rate: Double {
+        guard expectedDays > 0 else { return 0 }
+        return Double(observedDays) / Double(expectedDays)
+    }
+}
+
+public struct AlignedHealthDay: Identifiable, Sendable, Equatable {
+    public let date: Date
+    public let values: [HealthKitService.MetricKind: Double]
+
+    public var id: Date { date }
+}
+
+public struct LongitudinalHealthDataset: Sendable, Equatable {
+    public let expectedDays: Int
+    public let days: [AlignedHealthDay]
+    public let coverage: [LongitudinalMetricCoverage]
+
+    public func values(
+        for metricKind: HealthKitService.MetricKind
+    ) -> [(date: Date, value: Double)] {
+        days.compactMap { day in
+            guard let value = day.values[metricKind] else { return nil }
+            return (day.date, value)
+        }
+    }
+
+    public func pairedValues(
+        _ first: HealthKitService.MetricKind,
+        _ second: HealthKitService.MetricKind
+    ) -> [(date: Date, first: Double, second: Double)] {
+        days.compactMap { day in
+            guard let firstValue = day.values[first],
+                  let secondValue = day.values[second] else {
+                return nil
+            }
+            return (day.date, firstValue, secondValue)
+        }
+    }
+}
+
+public enum LongitudinalHealthAligner {
+    /// Aligns only observed daily values. Missing days remain absent and are never imputed as zero.
+    public static func align(
+        series: [HealthKitService.MetricKind: [HealthKitService.DailyMetric]],
+        expectedDays: Int,
+        calendar: Calendar = .current
+    ) -> LongitudinalHealthDataset {
+        var buckets: [Date: [HealthKitService.MetricKind: [Double]]] = [:]
+
+        for (kind, points) in series {
+            for point in points where point.isObserved && point.value.isFinite {
+                let day = calendar.startOfDay(for: point.date)
+                buckets[day, default: [:]][kind, default: []].append(point.value)
+            }
+        }
+
+        let days = buckets.keys.sorted().map { date in
+            let values = buckets[date, default: [:]].mapValues { samples in
+                samples.reduce(0, +) / Double(samples.count)
+            }
+            return AlignedHealthDay(date: date, values: values)
+        }
+
+        let normalizedExpectedDays = max(0, expectedDays)
+        let coverage = series.keys.sorted { $0.rawValue < $1.rawValue }.map { kind in
+            let observedDays = days.reduce(into: 0) { count, day in
+                if day.values[kind] != nil {
+                    count += 1
+                }
+            }
+            return LongitudinalMetricCoverage(
+                metricKind: kind,
+                observedDays: observedDays,
+                expectedDays: normalizedExpectedDays,
+                dataQuality: .classify(
+                    observedDays: observedDays,
+                    expectedDays: normalizedExpectedDays
+                )
+            )
+        }
+
+        return LongitudinalHealthDataset(
+            expectedDays: normalizedExpectedDays,
+            days: days,
+            coverage: coverage
+        )
+    }
+}

--- a/S2Y/HealthKit/PersonalHealthBaseline.swift
+++ b/S2Y/HealthKit/PersonalHealthBaseline.swift
@@ -1,0 +1,128 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public struct PersonalMetricBaseline: Sendable, Equatable {
+    public enum Availability: String, Sendable, Equatable {
+        case insufficientData
+        case available
+    }
+
+    public let metricKind: HealthKitService.MetricKind
+    public let availability: Availability
+    public let observedDays: Int
+    public let baselineMedian: Double?
+    public let medianAbsoluteDeviation: Double?
+}
+
+public struct PersonalMetricDeviation: Sendable, Equatable {
+    public enum Direction: String, Sendable, Equatable {
+        case lower
+        case typical
+        case higher
+        case undetermined
+    }
+
+    public let metricKind: HealthKitService.MetricKind
+    public let currentMedian: Double?
+    public let baselineMedian: Double?
+    public let robustDistance: Double?
+    public let direction: Direction
+    public let baselineObservedDays: Int
+    public let currentObservedDays: Int
+}
+
+public enum PersonalHealthBaselineAnalyzer {
+    public static let minimumBaselineDays = 14
+    public static let minimumCurrentDays = 3
+
+    public static func baseline(
+        for metricKind: HealthKitService.MetricKind,
+        values: [Double]
+    ) -> PersonalMetricBaseline {
+        let finiteValues = values.filter(\.isFinite)
+        guard finiteValues.count >= minimumBaselineDays,
+              let median = finiteValues.median else {
+            return PersonalMetricBaseline(
+                metricKind: metricKind,
+                availability: .insufficientData,
+                observedDays: finiteValues.count,
+                baselineMedian: nil,
+                medianAbsoluteDeviation: nil
+            )
+        }
+        let absoluteDeviations = finiteValues.map { abs($0 - median) }
+        return PersonalMetricBaseline(
+            metricKind: metricKind,
+            availability: .available,
+            observedDays: finiteValues.count,
+            baselineMedian: median,
+            medianAbsoluteDeviation: absoluteDeviations.median ?? 0
+        )
+    }
+
+    public static func deviation(
+        baselineValues: [Double],
+        currentValues: [Double],
+        metricKind: HealthKitService.MetricKind
+    ) -> PersonalMetricDeviation {
+        let baseline = baseline(for: metricKind, values: baselineValues)
+        let finiteCurrent = currentValues.filter(\.isFinite)
+        guard baseline.availability == .available,
+              finiteCurrent.count >= minimumCurrentDays,
+              let baselineMedian = baseline.baselineMedian,
+              let currentMedian = finiteCurrent.median,
+              let medianAbsoluteDeviation = baseline.medianAbsoluteDeviation else {
+            return PersonalMetricDeviation(
+                metricKind: metricKind,
+                currentMedian: finiteCurrent.median,
+                baselineMedian: baseline.baselineMedian,
+                robustDistance: nil,
+                direction: .undetermined,
+                baselineObservedDays: baseline.observedDays,
+                currentObservedDays: finiteCurrent.count
+            )
+        }
+
+        // 1.4826 makes MAD comparable to standard deviation for normally distributed data.
+        let robustScale = medianAbsoluteDeviation * 1.4826
+        let minimumScale = max(abs(baselineMedian) * 0.05, 1e-9)
+        let distance = (currentMedian - baselineMedian) / max(robustScale, minimumScale)
+        let direction: PersonalMetricDeviation.Direction
+        if distance > 2.5 {
+            direction = .higher
+        } else if distance < -2.5 {
+            direction = .lower
+        } else {
+            direction = .typical
+        }
+
+        return PersonalMetricDeviation(
+            metricKind: metricKind,
+            currentMedian: currentMedian,
+            baselineMedian: baselineMedian,
+            robustDistance: distance,
+            direction: direction,
+            baselineObservedDays: baseline.observedDays,
+            currentObservedDays: finiteCurrent.count
+        )
+    }
+}
+
+private extension Array where Element == Double {
+    var median: Double? {
+        guard !isEmpty else { return nil }
+        let sortedValues = sorted()
+        let middle = sortedValues.count / 2
+        if sortedValues.count.isMultiple(of: 2) {
+            return (sortedValues[middle - 1] + sortedValues[middle]) / 2
+        }
+        return sortedValues[middle]
+    }
+}

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -583,4 +583,35 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(relationship.availability, .insufficientData)
         XCTAssertNil(relationship.coefficient)
     }
+
+    func testPersonalInsightReportRetainsCoverageAndTraceability() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let start = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-07-01T12:00:00Z"))
+        var steps: [HealthKitService.DailyMetric] = []
+        var sleep: [HealthKitService.DailyMetric] = []
+        for offset in 0..<30 {
+            let date = try XCTUnwrap(calendar.date(byAdding: .day, value: offset, to: start))
+            steps.append(.init(date: date, value: offset < 23 ? 5_000 : 8_000))
+            sleep.append(.init(date: date, value: offset < 23 ? 7 : 8))
+        }
+        let dataset = LongitudinalHealthAligner.align(
+            series: [.steps: steps, .sleepDurationHours: sleep],
+            expectedDays: 30,
+            calendar: calendar
+        )
+
+        let report = PersonalHealthInsightBuilder.build(dataset: dataset, generatedAt: start)
+
+        XCTAssertEqual(report.coverage.count, 2)
+        XCTAssertEqual(report.coverage.first(where: { $0.metricKind == .steps })?.observedDays, 30)
+        XCTAssertEqual(report.deviations.first(where: { $0.metricKind == .steps })?.direction, .higher)
+        XCTAssertEqual(report.relationships.first?.pairedDays, 30)
+        XCTAssertTrue(report.hasUsableInsight)
+    }
+
+    func testPersonalInsightIntentIsExplicit() {
+        XCTAssertTrue(PersonalHealthInsightLoader.matches("Show patterns in my health data"))
+        XCTAssertTrue(PersonalHealthInsightLoader.matches("我的健康数据有什么关联"))
+        XCTAssertFalse(PersonalHealthInsightLoader.matches("How many steps today?"))
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -535,4 +535,52 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(deviation.direction, .undetermined)
         XCTAssertNil(deviation.robustDistance)
     }
+
+    func testDescriptiveRelationshipUsesOnlyPairedDaysAndRejectsCausality() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let start = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T12:00:00Z"))
+        var steps: [HealthKitService.DailyMetric] = []
+        var sleep: [HealthKitService.DailyMetric] = []
+        for offset in 0..<7 {
+            let date = try XCTUnwrap(calendar.date(byAdding: .day, value: offset, to: start))
+            steps.append(.init(date: date, value: Double(offset + 1) * 1_000))
+            sleep.append(.init(date: date, value: Double(offset + 1)))
+        }
+        let dataset = LongitudinalHealthAligner.align(
+            series: [.steps: steps, .sleepDurationHours: sleep],
+            expectedDays: 7,
+            calendar: calendar
+        )
+
+        let relationship = DescriptiveHealthRelationshipAnalyzer.analyze(
+            dataset: dataset,
+            first: .steps,
+            second: .sleepDurationHours
+        )
+
+        XCTAssertEqual(relationship.pairedDays, 7)
+        XCTAssertEqual(relationship.direction, .movesTogether)
+        XCTAssertEqual(relationship.strength, .strong)
+        XCTAssertTrue(relationship.explanation.contains("not evidence that one caused the other"))
+    }
+
+    func testDescriptiveRelationshipRequiresSevenPairedDays() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T12:00:00Z"))
+        let dataset = LongitudinalHealthAligner.align(
+            series: [
+                .steps: [.init(date: date, value: 5_000)],
+                .sleepDurationHours: [.init(date: date, value: 7)]
+            ],
+            expectedDays: 30
+        )
+
+        let relationship = DescriptiveHealthRelationshipAnalyzer.analyze(
+            dataset: dataset,
+            first: .steps,
+            second: .sleepDurationHours
+        )
+
+        XCTAssertEqual(relationship.availability, .insufficientData)
+        XCTAssertNil(relationship.coefficient)
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -454,4 +454,48 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(context.contains("Coverage is limited"))
         XCTAssertTrue(context.contains("not a diagnosis or treatment recommendation"))
     }
+
+    func testLongitudinalDatasetAlignsObservedValuesWithoutZeroImputation() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let start = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T12:00:00Z"))
+        let dayTwo = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: start))
+        let dataset = LongitudinalHealthAligner.align(
+            series: [
+                .steps: [
+                    .init(date: start, value: 4_000),
+                    .init(date: dayTwo, value: 0, isObserved: false)
+                ],
+                .sleepDurationHours: [
+                    .init(date: dayTwo, value: 7.5)
+                ]
+            ],
+            expectedDays: 7,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(dataset.days.count, 2)
+        XCTAssertEqual(dataset.values(for: .steps).map(\.value), [4_000])
+        XCTAssertEqual(dataset.values(for: .sleepDurationHours).map(\.value), [7.5])
+        XCTAssertTrue(dataset.pairedValues(.steps, .sleepDurationHours).isEmpty)
+        XCTAssertEqual(dataset.coverage.first(where: { $0.metricKind == .steps })?.observedDays, 1)
+    }
+
+    func testLongitudinalDatasetAveragesDuplicateSamplesWithinDay() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let morning = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T08:00:00Z"))
+        let evening = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-01T20:00:00Z"))
+        let dataset = LongitudinalHealthAligner.align(
+            series: [
+                .heartRateAverage: [
+                    .init(date: morning, value: 60),
+                    .init(date: evening, value: 80)
+                ]
+            ],
+            expectedDays: 1,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(dataset.values(for: .heartRateAverage).map(\.value), [70])
+        XCTAssertEqual(dataset.coverage.first?.dataQuality, .complete)
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -498,4 +498,41 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(dataset.values(for: .heartRateAverage).map(\.value), [70])
         XCTAssertEqual(dataset.coverage.first?.dataQuality, .complete)
     }
+
+    func testPersonalBaselineRequiresFourteenObservedDays() {
+        let baseline = PersonalHealthBaselineAnalyzer.baseline(
+            for: .restingHeartRate,
+            values: Array(repeating: 60, count: 13)
+        )
+
+        XCTAssertEqual(baseline.availability, .insufficientData)
+        XCTAssertNil(baseline.baselineMedian)
+    }
+
+    func testPersonalDeviationUsesRobustIndividualBaseline() {
+        let baselineValues = [58, 59, 60, 61, 62, 58, 59, 60, 61, 62, 59, 60, 61, 60]
+            .map(Double.init)
+
+        let deviation = PersonalHealthBaselineAnalyzer.deviation(
+            baselineValues: baselineValues,
+            currentValues: [72, 73, 74],
+            metricKind: .restingHeartRate
+        )
+
+        XCTAssertEqual(deviation.baselineMedian, 60)
+        XCTAssertEqual(deviation.currentMedian, 73)
+        XCTAssertEqual(deviation.direction, .higher)
+        XCTAssertEqual(deviation.baselineObservedDays, 14)
+    }
+
+    func testPersonalDeviationIsUndeterminedWithTooFewCurrentDays() {
+        let deviation = PersonalHealthBaselineAnalyzer.deviation(
+            baselineValues: Array(repeating: 7.5, count: 14),
+            currentValues: [5.5, 6],
+            metricKind: .sleepDurationHours
+        )
+
+        XCTAssertEqual(deviation.direction, .undetermined)
+        XCTAssertNil(deviation.robustDistance)
+    }
 }


### PR DESCRIPTION
## Theme
Build transparent, individual-first health insights from observed HealthKit history without population thresholds, fabricated correlations, or causal claims.

## Stories
- HLT-013: Align observed daily values across metrics and retain per-metric coverage without zero imputation.
- HLT-014: Establish a robust personal baseline using median/MAD with explicit minimum-data requirements.
- HLT-015: Calculate descriptive relationships from real overlapping days and state that association is not causation.
- HLT-016: Show traceable insight cards in Health Assistant with metric coverage, personal-baseline direction, and paired-day counts.

## Safety and privacy
- Raw samples remain in HealthKit; only derived in-memory summaries are displayed.
- A baseline requires at least 14 observed earlier days and 3 recent days.
- A relationship requires at least 7 paired days.
- Results describe higher/lower/typical patterns and never diagnose or infer causality.
- Chat does not request additional Health permissions.

## Verification
- All S2Y unit tests pass on iPhone 16e simulator (iOS 26.2).
- Generic iOS Simulator build passes with signing disabled.
- The untracked BrandAssets directory remains excluded.

## Stack note
This PR intentionally targets EPIC-H03 (#33). After #33 merges, its base should be changed to main.

## Related roadmap
Advances #11 and #12.