### PR TITLE
EPIC-H05: Add user-controlled wellbeing plans

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -42,6 +42,14 @@ struct HealthAssistantSettingsView: View {
                 Text("When Omer Online is selected, this allows a short summary of relevant Health data to be included with your question. On-device analysis stays on your iPhone, while chat history may still sync to your S2Y account.")
             }
 
+            Section("Plan") {
+                NavigationLink {
+                    WellnessPlanSettingsView()
+                } label: {
+                    Label("Wellbeing Plan", systemImage: "list.bullet.clipboard")
+                }
+            }
+
             Section {
                 Button("Clear Health data cache", role: .destructive) {
                     HealthKitCache.shared.clearAll()

--- a/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
@@ -1,0 +1,243 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+struct WellnessActionRecord: Codable, Identifiable, Sendable, Equatable {
+    enum Outcome: String, Codable, Sendable {
+        case completed
+        case skipped
+    }
+
+    let id: UUID
+    let planID: UUID
+    let actionID: UUID
+    let day: Date
+    let outcome: Outcome
+    let recordedAt: Date
+}
+
+enum WellnessDailySchedule {
+    static func actions(
+        for plan: WellnessPlan,
+        on date: Date,
+        calendar: Calendar = .current
+    ) -> [WellnessAction] {
+        guard plan.status == .active else { return [] }
+        let weekday = calendar.component(.weekday, from: date)
+        return plan.actions.filter { action in
+            action.daysPerWeek >= 7 || weekday <= action.daysPerWeek
+        }
+    }
+}
+
+@MainActor
+final class WellnessActionRecordStore: ObservableObject {
+    static let shared = WellnessActionRecordStore()
+
+    @Published private(set) var records: [WellnessActionRecord] = []
+
+    private let defaults: UserDefaults
+    private let storageKey = "wellnessActionRecords.v1"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode([WellnessActionRecord].self, from: data) {
+            records = decoded
+        }
+    }
+
+    func record(
+        planID: UUID,
+        actionID: UUID,
+        outcome: WellnessActionRecord.Outcome,
+        on date: Date = .now,
+        calendar: Calendar = .current
+    ) {
+        let day = calendar.startOfDay(for: date)
+        records.removeAll { $0.planID == planID && $0.actionID == actionID && calendar.isDate($0.day, inSameDayAs: day) }
+        records.append(WellnessActionRecord(
+            id: UUID(),
+            planID: planID,
+            actionID: actionID,
+            day: day,
+            outcome: outcome,
+            recordedAt: date
+        ))
+        persist()
+    }
+
+    func outcome(
+        planID: UUID,
+        actionID: UUID,
+        on date: Date = .now,
+        calendar: Calendar = .current
+    ) -> WellnessActionRecord.Outcome? {
+        records.last { record in
+            record.planID == planID
+                && record.actionID == actionID
+                && calendar.isDate(record.day, inSameDayAs: date)
+        }?.outcome
+    }
+
+    func undo(planID: UUID, actionID: UUID, on date: Date = .now, calendar: Calendar = .current) {
+        records.removeAll { record in
+            record.planID == planID
+                && record.actionID == actionID
+                && calendar.isDate(record.day, inSameDayAs: date)
+        }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}
+
+struct WellnessPlanSettingsView: View {
+    @StateObject private var planStore = WellnessPlanStore.shared
+    @StateObject private var recordStore = WellnessActionRecordStore.shared
+    @State private var isCreatingDraft = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            if let plan = planStore.currentPlan {
+                planSection(plan)
+                if plan.status == .active {
+                    todaySection(plan)
+                }
+            } else {
+                ContentUnavailableView(
+                    "No wellbeing plan",
+                    systemImage: "list.bullet.clipboard",
+                    description: Text("Create a draft from your recent personal patterns, then review it before activation.")
+                )
+            }
+
+            Section {
+                Button {
+                    Task { await createDraft() }
+                } label: {
+                    if isCreatingDraft {
+                        ProgressView()
+                    } else {
+                        Label("Create draft from recent data", systemImage: "sparkles")
+                    }
+                }
+                .disabled(isCreatingDraft || planStore.currentPlan?.status == .active)
+            } footer: {
+                Text("S2Y creates an editable health-management draft. It never activates a plan or schedules an intervention without your confirmation.")
+            }
+        }
+        .navigationTitle("Wellbeing Plan")
+        .alert("Plan unavailable", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private func planSection(_ plan: WellnessPlan) -> some View {
+        Section("Current Plan") {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(plan.title).font(.headline)
+                Text(plan.summary).font(.caption).foregroundStyle(.secondary)
+                LabeledContent("Status", value: plan.status.rawValue.capitalized)
+            }
+            ForEach(plan.actions) { action in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(action.title).font(.subheadline.weight(.semibold))
+                    Text(action.detail).font(.caption).foregroundStyle(.secondary)
+                    Text("\(action.daysPerWeek) days/week · about \(action.estimatedMinutes) min")
+                        .font(.caption2).foregroundStyle(.tertiary)
+                }
+            }
+            if plan.status == .draft {
+                Button("Review complete — activate plan") {
+                    do {
+                        planStore.save(try WellnessPlanLifecycle.transition(plan, to: .active))
+                    } catch {
+                        errorMessage = "This draft needs at least one personal goal and one action before activation."
+                    }
+                }
+            } else if plan.status == .active {
+                Button("Pause plan") {
+                    if let updated = try? WellnessPlanLifecycle.transition(plan, to: .paused) {
+                        planStore.save(updated)
+                    }
+                }
+            } else if plan.status == .paused {
+                Button("Resume plan") {
+                    if let updated = try? WellnessPlanLifecycle.transition(plan, to: .active) {
+                        planStore.save(updated)
+                    }
+                }
+            }
+            if plan.status != .archived {
+                Button("Archive plan", role: .destructive) {
+                    if let updated = try? WellnessPlanLifecycle.transition(plan, to: .archived) {
+                        planStore.save(updated)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func todaySection(_ plan: WellnessPlan) -> some View {
+        let actions = WellnessDailySchedule.actions(for: plan, on: .now)
+        Section("Today") {
+            if actions.isEmpty {
+                Text("No actions scheduled today.").foregroundStyle(.secondary)
+            }
+            ForEach(actions) { action in
+                let outcome = recordStore.outcome(planID: plan.id, actionID: action.id)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(action.title)
+                    if let outcome {
+                        Label(outcome == .completed ? "Completed" : "Skipped", systemImage: outcome == .completed ? "checkmark.circle.fill" : "forward.circle")
+                            .foregroundStyle(.secondary)
+                        Button("Undo") {
+                            recordStore.undo(planID: plan.id, actionID: action.id)
+                        }
+                        .font(.caption)
+                    } else {
+                        HStack {
+                            Button("Complete") {
+                                recordStore.record(planID: plan.id, actionID: action.id, outcome: .completed)
+                            }
+                            Button("Skip") {
+                                recordStore.record(planID: plan.id, actionID: action.id, outcome: .skipped)
+                            }
+                            .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+            }
+        }
+    }
+
+    private func createDraft() async {
+        isCreatingDraft = true
+        defer { isCreatingDraft = false }
+        guard let report = await PersonalHealthInsightLoader.load(for: "Show my health patterns") else {
+            errorMessage = "More readable Health data is needed before S2Y can create a personalized draft."
+            return
+        }
+        planStore.save(WellnessPlanDraftBuilder.build(from: report).plan)
+    }
+}

--- a/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
@@ -115,6 +115,13 @@ struct WellnessPlanSettingsView: View {
                 if plan.status == .active {
                     todaySection(plan)
                 }
+                Section {
+                    NavigationLink {
+                        WellnessWeeklyReviewView()
+                    } label: {
+                        Label("Weekly Review", systemImage: "calendar.badge.clock")
+                    }
+                }
             } else {
                 ContentUnavailableView(
                     "No wellbeing plan",

--- a/S2Y/WellnessPlan/WellnessPlanDraftBuilder.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDraftBuilder.swift
@@ -1,0 +1,121 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+struct WellnessPlanDraft: Sendable, Equatable {
+    let plan: WellnessPlan
+    let rationale: [String]
+    let limitations: [String]
+}
+
+enum WellnessPlanDraftBuilder {
+    static func build(
+        from report: PersonalHealthInsightReport,
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> WellnessPlanDraft {
+        let reviewDate = calendar.date(byAdding: .day, value: 14, to: now) ?? now
+        var goals: [WellnessGoal] = []
+        var actions: [WellnessAction] = []
+        var rationale: [String] = []
+
+        for deviation in report.deviations where deviation.direction != .undetermined {
+            guard let currentMedian = deviation.currentMedian else { continue }
+            switch deviation.metricKind {
+            case .sleepDurationHours:
+                goals.append(WellnessGoal(
+                    metricKind: .sleepDurationHours,
+                    direction: .consistency,
+                    targetValue: currentMedian,
+                    targetUnit: deviation.metricKind.unit,
+                    reviewDate: reviewDate
+                ))
+                actions.append(WellnessAction(
+                    title: "Keep a consistent wind-down window",
+                    detail: "Choose a realistic bedtime routine and adjust it whenever it no longer fits.",
+                    category: .sleepRoutine,
+                    daysPerWeek: 5,
+                    estimatedMinutes: 20
+                ))
+                rationale.append("Recent sleep was compared with your own earlier baseline using \(deviation.currentObservedDays) recent and \(deviation.baselineObservedDays) baseline days.")
+            case .steps, .activeEnergy:
+                goals.append(WellnessGoal(
+                    metricKind: deviation.metricKind,
+                    direction: deviation.direction == .lower ? .increase : .maintain,
+                    targetValue: currentMedian,
+                    targetUnit: deviation.metricKind.unit,
+                    reviewDate: reviewDate
+                ))
+                actions.append(WellnessAction(
+                    title: "Choose a comfortable movement break",
+                    detail: "Try a short walk or another comfortable activity. Stop or adjust if it does not feel right.",
+                    category: .movement,
+                    daysPerWeek: 4,
+                    estimatedMinutes: 10
+                ))
+                rationale.append("Recent \(deviation.metricKind.displayName.lowercased()) was compared with your own earlier baseline, not a population target.")
+            case .restingHeartRate, .heartRateAverage, .heartRateVariability:
+                goals.append(WellnessGoal(
+                    metricKind: deviation.metricKind,
+                    direction: .consistency,
+                    targetValue: nil,
+                    targetUnit: deviation.metricKind.unit,
+                    reviewDate: reviewDate
+                ))
+                actions.append(WellnessAction(
+                    title: "Add a quiet recovery check-in",
+                    detail: "Pause for slow breathing or a brief reflection. This is for general wellbeing, not treatment.",
+                    category: .recovery,
+                    daysPerWeek: 5,
+                    estimatedMinutes: 5
+                ))
+                rationale.append("Recent \(deviation.metricKind.displayName.lowercased()) differed from your personal baseline; the plan does not interpret the change medically.")
+            default:
+                continue
+            }
+        }
+
+        if actions.isEmpty {
+            actions = [WellnessAction(
+                title: "Complete a brief wellbeing check-in",
+                detail: "Record how you feel so future summaries have more context.",
+                category: .checkIn,
+                daysPerWeek: 3,
+                estimatedMinutes: 2,
+                isOptional: true
+            )]
+            rationale.append("There is not enough personal baseline data for a metric-specific draft yet.")
+        }
+
+        let plan = WellnessPlan(
+            title: "My two-week wellbeing plan",
+            summary: "A flexible health-management draft based on your observed data. Review and edit it before activation.",
+            status: .draft,
+            origin: .assistantDraft,
+            goals: goals,
+            actions: deduplicate(actions),
+            createdAt: now,
+            updatedAt: now
+        )
+        return WellnessPlanDraft(
+            plan: plan,
+            rationale: rationale,
+            limitations: [
+                "This draft is for general wellbeing and health management, not diagnosis or treatment.",
+                "Associations in your data do not show that one behavior caused another outcome.",
+                "Nothing is scheduled or activated until you confirm the draft."
+            ]
+        )
+    }
+
+    private static func deduplicate(_ actions: [WellnessAction]) -> [WellnessAction] {
+        var categories: Set<WellnessAction.Category> = []
+        return actions.filter { categories.insert($0.category).inserted }
+    }
+}

--- a/S2Y/WellnessPlan/WellnessPlanModels.swift
+++ b/S2Y/WellnessPlan/WellnessPlanModels.swift
@@ -1,0 +1,215 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public struct WellnessGoal: Codable, Identifiable, Sendable, Equatable {
+    public enum Direction: String, Codable, Sendable {
+        case increase
+        case decrease
+        case maintain
+        case consistency
+    }
+
+    public let id: UUID
+    public let metricKind: HealthKitService.MetricKind
+    public var direction: Direction
+    public var targetValue: Double?
+    public var targetUnit: String
+    public var reviewDate: Date
+
+    public init(
+        id: UUID = UUID(),
+        metricKind: HealthKitService.MetricKind,
+        direction: Direction,
+        targetValue: Double?,
+        targetUnit: String,
+        reviewDate: Date
+    ) {
+        self.id = id
+        self.metricKind = metricKind
+        self.direction = direction
+        self.targetValue = targetValue
+        self.targetUnit = targetUnit
+        self.reviewDate = reviewDate
+    }
+}
+
+public struct WellnessAction: Codable, Identifiable, Sendable, Equatable {
+    public enum Category: String, Codable, Sendable, CaseIterable {
+        case movement
+        case sleepRoutine
+        case recovery
+        case mindfulness
+        case checkIn
+    }
+
+    public let id: UUID
+    public var title: String
+    public var detail: String
+    public var category: Category
+    public var daysPerWeek: Int
+    public var estimatedMinutes: Int
+    public var isOptional: Bool
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        detail: String,
+        category: Category,
+        daysPerWeek: Int,
+        estimatedMinutes: Int,
+        isOptional: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.category = category
+        self.daysPerWeek = min(7, max(1, daysPerWeek))
+        self.estimatedMinutes = max(1, estimatedMinutes)
+        self.isOptional = isOptional
+    }
+}
+
+public struct WellnessPlan: Codable, Identifiable, Sendable, Equatable {
+    public enum Status: String, Codable, Sendable {
+        case draft
+        case active
+        case paused
+        case completed
+        case archived
+    }
+
+    public enum Origin: String, Codable, Sendable {
+        case userCreated
+        case assistantDraft
+    }
+
+    public let id: UUID
+    public var title: String
+    public var summary: String
+    public var status: Status
+    public var origin: Origin
+    public var goals: [WellnessGoal]
+    public var actions: [WellnessAction]
+    public let createdAt: Date
+    public var updatedAt: Date
+    public var activatedAt: Date?
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        summary: String,
+        status: Status = .draft,
+        origin: Origin,
+        goals: [WellnessGoal],
+        actions: [WellnessAction],
+        createdAt: Date = .now,
+        updatedAt: Date = .now,
+        activatedAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.status = status
+        self.origin = origin
+        self.goals = goals
+        self.actions = actions
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.activatedAt = activatedAt
+    }
+}
+
+public enum WellnessPlanTransitionError: Error, Equatable {
+    case invalidTransition
+    case emptyPlan
+}
+
+public enum WellnessPlanLifecycle {
+    public static func transition(
+        _ plan: WellnessPlan,
+        to status: WellnessPlan.Status,
+        at date: Date = .now
+    ) throws -> WellnessPlan {
+        if status == .active, plan.goals.isEmpty || plan.actions.isEmpty {
+            throw WellnessPlanTransitionError.emptyPlan
+        }
+        let allowed: Set<WellnessPlan.Status>
+        switch plan.status {
+        case .draft:
+            allowed = [.active, .archived]
+        case .active:
+            allowed = [.paused, .completed, .archived]
+        case .paused:
+            allowed = [.active, .archived]
+        case .completed:
+            allowed = [.archived]
+        case .archived:
+            allowed = []
+        }
+        guard allowed.contains(status) else {
+            throw WellnessPlanTransitionError.invalidTransition
+        }
+        var updated = plan
+        updated.status = status
+        updated.updatedAt = date
+        if status == .active, updated.activatedAt == nil {
+            updated.activatedAt = date
+        }
+        return updated
+    }
+}
+
+@MainActor
+final class WellnessPlanStore: ObservableObject {
+    static let shared = WellnessPlanStore()
+
+    @Published private(set) var plans: [WellnessPlan] = []
+
+    private let defaults: UserDefaults
+    private let storageKey = "wellnessPlans.v1"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        load()
+    }
+
+    var currentPlan: WellnessPlan? {
+        plans.first { $0.status == .active || $0.status == .paused || $0.status == .draft }
+    }
+
+    func save(_ plan: WellnessPlan) {
+        if let index = plans.firstIndex(where: { $0.id == plan.id }) {
+            plans[index] = plan
+        } else {
+            plans.insert(plan, at: 0)
+        }
+        persist()
+    }
+
+    func removeArchivedPlans() {
+        plans.removeAll { $0.status == .archived }
+        persist()
+    }
+
+    private func load() {
+        guard let data = defaults.data(forKey: storageKey),
+              let decoded = try? decoder.decode([WellnessPlan].self, from: data) else {
+            return
+        }
+        plans = decoded
+    }
+
+    private func persist() {
+        guard let data = try? encoder.encode(plans) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/S2Y/WellnessPlan/WellnessWeeklyReview.swift
+++ b/S2Y/WellnessPlan/WellnessWeeklyReview.swift
@@ -1,0 +1,144 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+struct WellnessWeeklyReview: Sendable, Equatable {
+    enum Adjustment: String, Sendable {
+        case considerSimplifying
+        case keepFlexible
+        case maintain
+    }
+
+    let scheduledCount: Int
+    let completedCount: Int
+    let skippedCount: Int
+    let unrecordedCount: Int
+    let adjustment: Adjustment
+
+    var completionRate: Double? {
+        guard scheduledCount > 0 else { return nil }
+        return Double(completedCount) / Double(scheduledCount)
+    }
+}
+
+enum WellnessWeeklyReviewBuilder {
+    static func build(
+        plan: WellnessPlan,
+        records: [WellnessActionRecord],
+        endingAt end: Date = .now,
+        calendar: Calendar = .current
+    ) -> WellnessWeeklyReview {
+        guard plan.status == .active || plan.status == .paused else {
+            return WellnessWeeklyReview(
+                scheduledCount: 0,
+                completedCount: 0,
+                skippedCount: 0,
+                unrecordedCount: 0,
+                adjustment: .keepFlexible
+            )
+        }
+        let endDay = calendar.startOfDay(for: end)
+        let startDay = calendar.date(byAdding: .day, value: -6, to: endDay) ?? endDay
+        var scheduledKeys: Set<String> = []
+        for offset in 0..<7 {
+            guard let day = calendar.date(byAdding: .day, value: offset, to: startDay) else { continue }
+            for action in WellnessDailySchedule.actions(for: plan, on: day, calendar: calendar) {
+                scheduledKeys.insert(key(actionID: action.id, day: day, calendar: calendar))
+            }
+        }
+
+        let relevantRecords = records.filter { record in
+            let recordDay = calendar.startOfDay(for: record.day)
+            return record.planID == plan.id && recordDay >= startDay && recordDay <= endDay
+                && scheduledKeys.contains(key(actionID: record.actionID, day: recordDay, calendar: calendar))
+        }
+        let latestByKey = Dictionary(grouping: relevantRecords) { record in
+            key(actionID: record.actionID, day: record.day, calendar: calendar)
+        }.compactMapValues { $0.max(by: { $0.recordedAt < $1.recordedAt }) }
+        let completed = latestByKey.values.filter { $0.outcome == .completed }.count
+        let skipped = latestByKey.values.filter { $0.outcome == .skipped }.count
+        let unrecorded = max(0, scheduledKeys.count - latestByKey.count)
+        let rate = scheduledKeys.isEmpty ? nil : Double(completed) / Double(scheduledKeys.count)
+        let adjustment: WellnessWeeklyReview.Adjustment
+        if let rate, rate < 0.5 {
+            adjustment = .considerSimplifying
+        } else if unrecorded > completed + skipped {
+            adjustment = .keepFlexible
+        } else {
+            adjustment = .maintain
+        }
+        return WellnessWeeklyReview(
+            scheduledCount: scheduledKeys.count,
+            completedCount: completed,
+            skippedCount: skipped,
+            unrecordedCount: unrecorded,
+            adjustment: adjustment
+        )
+    }
+
+    private static func key(actionID: UUID, day: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: day)
+        return "\(actionID.uuidString)|\(components.year ?? 0)-\(components.month ?? 0)-\(components.day ?? 0)"
+    }
+}
+
+struct WellnessWeeklyReviewView: View {
+    @StateObject private var planStore = WellnessPlanStore.shared
+    @StateObject private var recordStore = WellnessActionRecordStore.shared
+
+    var body: some View {
+        List {
+            if let plan = planStore.currentPlan {
+                let review = WellnessWeeklyReviewBuilder.build(plan: plan, records: recordStore.records)
+                Section("Last 7 Days") {
+                    LabeledContent("Planned", value: "\(review.scheduledCount)")
+                    LabeledContent("Completed", value: "\(review.completedCount)")
+                    LabeledContent("Skipped", value: "\(review.skippedCount)")
+                    LabeledContent("Not recorded", value: "\(review.unrecordedCount)")
+                }
+                Section("Reflection") {
+                    Text(reflection(for: review))
+                    Text("Not recorded does not mean failed. Use this review only to decide what feels realistic for the next week.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Section("Your Choice") {
+                    if plan.status == .active {
+                        Button("Pause for now") { transition(plan, to: .paused) }
+                        Button("Mark plan complete") { transition(plan, to: .completed) }
+                    } else if plan.status == .paused {
+                        Button("Resume plan") { transition(plan, to: .active) }
+                    }
+                    Button("End and archive plan", role: .destructive) { transition(plan, to: .archived) }
+                }
+            } else {
+                ContentUnavailableView("No plan to review", systemImage: "calendar.badge.clock")
+            }
+        }
+        .navigationTitle("Weekly Review")
+    }
+
+    private func reflection(for review: WellnessWeeklyReview) -> String {
+        switch review.adjustment {
+        case .considerSimplifying:
+            "The current plan may be asking for too much. Consider fewer days or shorter actions; no change is made automatically."
+        case .keepFlexible:
+            "There are several days without records. Keep the plan flexible and record only what is useful to you."
+        case .maintain:
+            "The current rhythm appears workable from the records available. You can keep it or change it at any time."
+        }
+    }
+
+    private func transition(_ plan: WellnessPlan, to status: WellnessPlan.Status) {
+        if let updated = try? WellnessPlanLifecycle.transition(plan, to: status) {
+            planStore.save(updated)
+        }
+    }
+}

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -735,4 +735,54 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(WellnessDailySchedule.actions(for: draft, on: date).isEmpty)
         XCTAssertEqual(WellnessDailySchedule.actions(for: active, on: date), [action])
     }
+
+    func testWeeklyReviewKeepsMissingRecordsSeparateFromSkipped() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let end = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-08T12:00:00Z"))
+        let action = WellnessAction(
+            title: "Daily check-in",
+            detail: "Brief reflection",
+            category: .checkIn,
+            daysPerWeek: 7,
+            estimatedMinutes: 2
+        )
+        let goal = WellnessGoal(
+            metricKind: .sleepDurationHours,
+            direction: .consistency,
+            targetValue: nil,
+            targetUnit: "hours",
+            reviewDate: end
+        )
+        let draft = WellnessPlan(
+            title: "Plan",
+            summary: "Summary",
+            origin: .userCreated,
+            goals: [goal],
+            actions: [action]
+        )
+        let plan = try WellnessPlanLifecycle.transition(draft, to: .active, at: end)
+        let records = [
+            WellnessActionRecord(
+                id: UUID(),
+                planID: plan.id,
+                actionID: action.id,
+                day: end,
+                outcome: .skipped,
+                recordedAt: end
+            )
+        ]
+
+        let review = WellnessWeeklyReviewBuilder.build(
+            plan: plan,
+            records: records,
+            endingAt: end,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(review.scheduledCount, 7)
+        XCTAssertEqual(review.skippedCount, 1)
+        XCTAssertEqual(review.unrecordedCount, 6)
+        XCTAssertEqual(review.adjustment, .considerSimplifying)
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -706,4 +706,33 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(draft.plan.actions.first?.category, .checkIn)
         XCTAssertTrue(draft.plan.actions.first?.isOptional == true)
     }
+
+    func testOnlyActiveWellnessPlansProduceDailyActions() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let goal = WellnessGoal(
+            metricKind: .steps,
+            direction: .maintain,
+            targetValue: 6_000,
+            targetUnit: "steps",
+            reviewDate: date
+        )
+        let action = WellnessAction(
+            title: "Movement break",
+            detail: "A comfortable activity",
+            category: .movement,
+            daysPerWeek: 7,
+            estimatedMinutes: 10
+        )
+        let draft = WellnessPlan(
+            title: "Plan",
+            summary: "Draft",
+            origin: .userCreated,
+            goals: [goal],
+            actions: [action]
+        )
+        let active = try WellnessPlanLifecycle.transition(draft, to: .active, at: date)
+
+        XCTAssertTrue(WellnessDailySchedule.actions(for: draft, on: date).isEmpty)
+        XCTAssertEqual(WellnessDailySchedule.actions(for: active, on: date), [action])
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -663,4 +663,47 @@ final class OmerMobileChatModelsTests: XCTestCase {
             XCTAssertEqual(error as? WellnessPlanTransitionError, .emptyPlan)
         }
     }
+
+    func testWellnessDraftUsesPersonalBaselineAndRequiresConfirmation() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let report = PersonalHealthInsightReport(
+            windowDays: 30,
+            generatedAt: date,
+            coverage: [],
+            deviations: [PersonalMetricDeviation(
+                metricKind: .sleepDurationHours,
+                currentMedian: 6.5,
+                baselineMedian: 7.5,
+                robustDistance: -3,
+                direction: .lower,
+                baselineObservedDays: 20,
+                currentObservedDays: 7
+            )],
+            relationships: []
+        )
+
+        let draft = WellnessPlanDraftBuilder.build(from: report, now: date)
+
+        XCTAssertEqual(draft.plan.status, .draft)
+        XCTAssertEqual(draft.plan.origin, .assistantDraft)
+        XCTAssertEqual(draft.plan.goals.first?.targetValue, 6.5)
+        XCTAssertTrue(draft.rationale.first?.contains("your own earlier baseline") == true)
+        XCTAssertTrue(draft.limitations.contains { $0.contains("until you confirm") })
+    }
+
+    func testWellnessDraftAvoidsMetricTargetsWhenBaselineIsInsufficient() {
+        let report = PersonalHealthInsightReport(
+            windowDays: 30,
+            generatedAt: .now,
+            coverage: [],
+            deviations: [],
+            relationships: []
+        )
+
+        let draft = WellnessPlanDraftBuilder.build(from: report)
+
+        XCTAssertTrue(draft.plan.goals.isEmpty)
+        XCTAssertEqual(draft.plan.actions.first?.category, .checkIn)
+        XCTAssertTrue(draft.plan.actions.first?.isOptional == true)
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -614,4 +614,53 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(PersonalHealthInsightLoader.matches("我的健康数据有什么关联"))
         XCTAssertFalse(PersonalHealthInsightLoader.matches("How many steps today?"))
     }
+
+    func testWellnessPlanRequiresExplicitValidActivation() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let goal = WellnessGoal(
+            metricKind: .sleepDurationHours,
+            direction: .consistency,
+            targetValue: nil,
+            targetUnit: "hours",
+            reviewDate: date.addingTimeInterval(14 * 86_400)
+        )
+        let action = WellnessAction(
+            title: "Keep a regular wind-down time",
+            detail: "Choose a realistic 20-minute wind-down window.",
+            category: .sleepRoutine,
+            daysPerWeek: 5,
+            estimatedMinutes: 20
+        )
+        let draft = WellnessPlan(
+            title: "Sleep consistency",
+            summary: "A user-controlled wellness plan.",
+            origin: .assistantDraft,
+            goals: [goal],
+            actions: [action],
+            createdAt: date,
+            updatedAt: date
+        )
+
+        let active = try WellnessPlanLifecycle.transition(draft, to: .active, at: date)
+        let paused = try WellnessPlanLifecycle.transition(active, to: .paused, at: date)
+
+        XCTAssertEqual(active.status, .active)
+        XCTAssertEqual(active.activatedAt, date)
+        XCTAssertEqual(paused.status, .paused)
+        XCTAssertThrowsError(try WellnessPlanLifecycle.transition(paused, to: .completed))
+    }
+
+    func testEmptyWellnessPlanCannotActivate() {
+        let plan = WellnessPlan(
+            title: "Empty",
+            summary: "No actions yet",
+            origin: .userCreated,
+            goals: [],
+            actions: []
+        )
+
+        XCTAssertThrowsError(try WellnessPlanLifecycle.transition(plan, to: .active)) { error in
+            XCTAssertEqual(error as? WellnessPlanTransitionError, .emptyPlan)
+        }
+    }
 }


### PR DESCRIPTION
## Theme
Turn personal observations into an editable, user-confirmed health-management plan with daily actions and non-judgmental weekly review.

## Stories
- HLT-017: Define goals, actions, persistence, and a consent-led draft/active/paused/completed/archived lifecycle.
- HLT-018: Create explainable two-week plan drafts from personal baselines without population targets or automatic activation.
- HLT-019: Add plan review/activation and reversible daily complete/skip records in Health Assistant settings.
- HLT-020: Add a seven-day review that keeps missing records separate from skipped actions and leaves every adjustment to the user.

## Safety and privacy
- Assistant output is always a draft; users explicitly activate it.
- Plans are for wellbeing and health management, not diagnosis or treatment.
- No action writes to HealthKit or sends commands to a Bluetooth device.
- Users can pause, complete, archive, skip, or undo at any time.
- Missing records are not treated as failure.

## Verification
- All S2Y unit tests pass on iPhone 16e simulator (iOS 26.2).
- Generic iOS Simulator build passes with signing disabled.
- The untracked BrandAssets directory remains excluded.

## Stack note
This PR intentionally targets EPIC-H04 (#34). After #34 merges, its base should be changed to main.

## Related roadmap
Advances #12, #13, and #15.