### PR TITLE
EPIC-H06: establish wellness device safety boundaries

### DIFF
--- a/S2Y/Bluetooth/BluetoothDevicesView.swift
+++ b/S2Y/Bluetooth/BluetoothDevicesView.swift
@@ -20,6 +20,7 @@ struct BluetoothDevicesView: View {
             scanningSection
             connectedDevicesSectionIfNeeded
             discoveredDevicesSectionIfNeeded
+            wellnessDeviceSafetySection
             supportedDevicesSection
         }
         .navigationTitle("Bluetooth Devices")
@@ -31,6 +32,27 @@ struct BluetoothDevicesView: View {
         }
         .sheet(item: $selectedDevice) { device in
             BluetoothDeviceDetailView(device: device)
+        }
+    }
+
+    @ViewBuilder
+    private var wellnessDeviceSafetySection: some View {
+        Section {
+            Label("No compatible wellness device configured", systemImage: "shield.checkered")
+                .foregroundStyle(.secondary)
+
+            NavigationLink {
+                WellnessSessionHistoryView()
+            } label: {
+                Label("Wellness Session History", systemImage: "clock.arrow.circlepath")
+            }
+        } header: {
+            Text("Wellness Device Safety")
+        } footer: {
+            Text(
+                "Wellness sessions remain unavailable until verified hardware is supported. "
+                    + "Any future session will require your confirmation and include an immediate stop control."
+            )
         }
     }
     
@@ -373,6 +395,49 @@ struct MeasurementRow: View {
             Text(unit)
                 .font(.caption)
                 .foregroundColor(.secondary)
+        }
+    }
+}
+
+private struct WellnessSessionHistoryView: View {
+    @StateObject private var auditStore = WellnessSessionAuditStore.shared
+
+    var body: some View {
+        List {
+            if auditStore.log.records.isEmpty {
+                ContentUnavailableView(
+                    "No Wellness Sessions",
+                    systemImage: "shield.checkered",
+                    description: Text("Session activity will be stored on this device for your review.")
+                )
+            } else {
+                ForEach(auditStore.log.records) { record in
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(record.purpose.displayName)
+                            .font(.headline)
+                        Text(
+                            "\(record.requestedDurationMinutes) min · Comfort level \(record.comfortLevel)"
+                        )
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        Text(record.confirmedAt, style: .date)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+            }
+        }
+        .navigationTitle("Session History")
+    }
+}
+
+private extension WellnessSessionPurpose {
+    var displayName: String {
+        switch self {
+        case .relaxation: "Relaxation"
+        case .mindfulBreak: "Mindful Break"
+        case .windDown: "Wind Down"
         }
     }
 }

--- a/S2Y/Bluetooth/WellnessDeviceSafety.swift
+++ b/S2Y/Bluetooth/WellnessDeviceSafety.swift
@@ -201,3 +201,122 @@ public struct WellnessSessionSafetyPolicy: Sendable {
         )
     }
 }
+
+public struct WellnessSessionConfirmationRequest: Sendable, Equatable {
+    public let id: UUID
+    public let session: ValidatedWellnessSession
+    public let presentedAt: Date
+}
+
+public struct ActiveWellnessSession: Sendable, Equatable {
+    public let session: ValidatedWellnessSession
+    public let confirmedAt: Date
+    public let scheduledEndAt: Date
+}
+
+public enum WellnessSessionStopReason: String, Sendable, Equatable {
+    case userStopped
+    case safetyStop
+    case completed
+    case confirmationCancelled
+}
+
+public struct StoppedWellnessSession: Sendable, Equatable {
+    public let request: WellnessSessionRequest
+    public let stoppedAt: Date
+    public let reason: WellnessSessionStopReason
+}
+
+public enum WellnessSessionState: Sendable, Equatable {
+    case idle
+    case awaitingConfirmation(WellnessSessionConfirmationRequest)
+    case active(ActiveWellnessSession)
+    case stopped(StoppedWellnessSession)
+}
+
+public enum WellnessSessionControlFailure: Error, Sendable, Equatable {
+    case confirmationNotPending
+    case confirmationMismatch
+    case confirmationExpired
+    case sessionNotActive
+}
+
+/// A local state machine that requires a fresh, explicit user confirmation.
+///
+/// It produces no Bluetooth payload. A future hardware adapter must accept only
+/// `ActiveWellnessSession` values from this controller and must always expose stop.
+public struct WellnessSessionController: Sendable {
+    public private(set) var state: WellnessSessionState = .idle
+
+    public init() {}
+
+    @discardableResult
+    public mutating func prepare(
+        _ session: ValidatedWellnessSession,
+        now: Date = .now
+    ) -> WellnessSessionConfirmationRequest {
+        let confirmation = WellnessSessionConfirmationRequest(
+            id: UUID(),
+            session: session,
+            presentedAt: now
+        )
+        state = .awaitingConfirmation(confirmation)
+        return confirmation
+    }
+
+    @discardableResult
+    public mutating func confirm(
+        confirmationID: UUID,
+        now: Date = .now
+    ) throws -> ActiveWellnessSession {
+        guard case let .awaitingConfirmation(pending) = state else {
+            throw WellnessSessionControlFailure.confirmationNotPending
+        }
+        guard pending.id == confirmationID else {
+            throw WellnessSessionControlFailure.confirmationMismatch
+        }
+        guard now <= pending.session.expiresAt else {
+            throw WellnessSessionControlFailure.confirmationExpired
+        }
+        let active = ActiveWellnessSession(
+            session: pending.session,
+            confirmedAt: now,
+            scheduledEndAt: now.addingTimeInterval(
+                TimeInterval(pending.session.request.durationMinutes * 60)
+            )
+        )
+        state = .active(active)
+        return active
+    }
+
+    public mutating func cancelConfirmation(now: Date = .now) throws {
+        guard case let .awaitingConfirmation(pending) = state else {
+            throw WellnessSessionControlFailure.confirmationNotPending
+        }
+        state = .stopped(
+            StoppedWellnessSession(
+                request: pending.session.request,
+                stoppedAt: now,
+                reason: .confirmationCancelled
+            )
+        )
+    }
+
+    /// Stops an active session without requiring a confirmation or network call.
+    @discardableResult
+    public mutating func stopImmediately(
+        reason: WellnessSessionStopReason = .userStopped,
+        now: Date = .now
+    ) throws -> StoppedWellnessSession {
+        guard case let .active(active) = state else {
+            throw WellnessSessionControlFailure.sessionNotActive
+        }
+        let stopped = StoppedWellnessSession(
+            request: active.session.request,
+            stoppedAt: now,
+            reason: reason
+        )
+        state = .stopped(stopped)
+        return stopped
+    }
+}

--- a/S2Y/Bluetooth/WellnessDeviceSafety.swift
+++ b/S2Y/Bluetooth/WellnessDeviceSafety.swift
@@ -214,7 +214,7 @@ public struct ActiveWellnessSession: Sendable, Equatable {
     public let scheduledEndAt: Date
 }
 
-public enum WellnessSessionStopReason: String, Sendable, Equatable {
+public enum WellnessSessionStopReason: String, Codable, Sendable, Equatable {
     case userStopped
     case safetyStop
     case completed

--- a/S2Y/Bluetooth/WellnessDeviceSafety.swift
+++ b/S2Y/Bluetooth/WellnessDeviceSafety.swift
@@ -1,0 +1,97 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+/// Capabilities a wellness device may expose after identity verification.
+///
+/// The app deliberately models abstract, user-facing capabilities here. Hardware
+/// parameters and medical treatment modes are not part of this contract.
+public enum WellnessDeviceCapability: String, Codable, Sendable, CaseIterable {
+    case relaxationSession
+    case levelAdjustment
+    case sessionTimer
+    case immediateStop
+    case batteryStatus
+}
+
+public struct WellnessDeviceIdentity: Codable, Sendable, Equatable {
+    public let deviceID: UUID
+    public let productIdentifier: String
+    public let firmwareVersion: String
+    public let protocolVersion: Int
+    public let reportedCapabilities: Set<WellnessDeviceCapability>
+    public let manufacturerSignatureValidated: Bool
+
+    public init(
+        deviceID: UUID,
+        productIdentifier: String,
+        firmwareVersion: String,
+        protocolVersion: Int,
+        reportedCapabilities: Set<WellnessDeviceCapability>,
+        manufacturerSignatureValidated: Bool
+    ) {
+        self.deviceID = deviceID
+        self.productIdentifier = productIdentifier
+        self.firmwareVersion = firmwareVersion
+        self.protocolVersion = protocolVersion
+        self.reportedCapabilities = reportedCapabilities
+        self.manufacturerSignatureValidated = manufacturerSignatureValidated
+    }
+}
+
+public struct VerifiedWellnessDevice: Sendable, Equatable {
+    public let identity: WellnessDeviceIdentity
+    public let allowedCapabilities: Set<WellnessDeviceCapability>
+}
+
+public enum WellnessDeviceTrustFailure: Error, Sendable, Equatable {
+    case invalidManufacturerSignature
+    case unsupportedProduct
+    case unsupportedProtocol
+    case missingImmediateStop
+    case noAllowedCapabilities
+}
+
+/// Fail-closed device identity and capability policy.
+public struct WellnessDeviceTrustPolicy: Sendable {
+    public let supportedProductIdentifiers: Set<String>
+    public let supportedProtocolVersions: ClosedRange<Int>
+    public let allowedCapabilities: Set<WellnessDeviceCapability>
+
+    public init(
+        supportedProductIdentifiers: Set<String>,
+        supportedProtocolVersions: ClosedRange<Int>,
+        allowedCapabilities: Set<WellnessDeviceCapability> = Set(WellnessDeviceCapability.allCases)
+    ) {
+        self.supportedProductIdentifiers = supportedProductIdentifiers
+        self.supportedProtocolVersions = supportedProtocolVersions
+        self.allowedCapabilities = allowedCapabilities
+    }
+
+    public func verify(_ identity: WellnessDeviceIdentity) throws -> VerifiedWellnessDevice {
+        guard identity.manufacturerSignatureValidated else {
+            throw WellnessDeviceTrustFailure.invalidManufacturerSignature
+        }
+        guard supportedProductIdentifiers.contains(identity.productIdentifier) else {
+            throw WellnessDeviceTrustFailure.unsupportedProduct
+        }
+        guard supportedProtocolVersions.contains(identity.protocolVersion) else {
+            throw WellnessDeviceTrustFailure.unsupportedProtocol
+        }
+        guard identity.reportedCapabilities.contains(.immediateStop) else {
+            throw WellnessDeviceTrustFailure.missingImmediateStop
+        }
+
+        let capabilities = identity.reportedCapabilities.intersection(allowedCapabilities)
+        guard !capabilities.isEmpty else {
+            throw WellnessDeviceTrustFailure.noAllowedCapabilities
+        }
+        return VerifiedWellnessDevice(identity: identity, allowedCapabilities: capabilities)
+    }
+}

--- a/S2Y/Bluetooth/WellnessDeviceSafety.swift
+++ b/S2Y/Bluetooth/WellnessDeviceSafety.swift
@@ -95,3 +95,109 @@ public struct WellnessDeviceTrustPolicy: Sendable {
         return VerifiedWellnessDevice(identity: identity, allowedCapabilities: capabilities)
     }
 }
+
+public enum WellnessSessionPurpose: String, Codable, Sendable, CaseIterable {
+    case relaxation
+    case mindfulBreak
+    case windDown
+}
+
+public enum WellnessSessionOrigin: String, Codable, Sendable {
+    case userCreated
+    case assistantDraft
+}
+
+/// A user-readable request that intentionally excludes hardware stimulation parameters.
+public struct WellnessSessionRequest: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let deviceID: UUID
+    public let purpose: WellnessSessionPurpose
+    public let durationMinutes: Int
+    public let comfortLevel: Int
+    public let origin: WellnessSessionOrigin
+
+    public init(
+        id: UUID = UUID(),
+        deviceID: UUID,
+        purpose: WellnessSessionPurpose,
+        durationMinutes: Int,
+        comfortLevel: Int,
+        origin: WellnessSessionOrigin
+    ) {
+        self.id = id
+        self.deviceID = deviceID
+        self.purpose = purpose
+        self.durationMinutes = durationMinutes
+        self.comfortLevel = comfortLevel
+        self.origin = origin
+    }
+}
+
+public struct ValidatedWellnessSession: Sendable, Equatable {
+    public let request: WellnessSessionRequest
+    public let validatedAt: Date
+    public let expiresAt: Date
+}
+
+public enum WellnessSessionValidationFailure: Error, Sendable, Equatable {
+    case deviceMismatch
+    case missingCapability(WellnessDeviceCapability)
+    case durationOutOfRange
+    case comfortLevelOutOfRange
+    case cooldownActive(until: Date)
+}
+
+/// Fixed local safety envelope. Server or AI suggestions cannot widen these bounds.
+public struct WellnessSessionSafetyPolicy: Sendable {
+    public let durationRange: ClosedRange<Int>
+    public let comfortLevelRange: ClosedRange<Int>
+    public let minimumCooldown: TimeInterval
+    public let validationLifetime: TimeInterval
+
+    public init(
+        durationRange: ClosedRange<Int> = 1 ... 20,
+        comfortLevelRange: ClosedRange<Int> = 1 ... 3,
+        minimumCooldown: TimeInterval = 60 * 60,
+        validationLifetime: TimeInterval = 5 * 60
+    ) {
+        self.durationRange = durationRange
+        self.comfortLevelRange = comfortLevelRange
+        self.minimumCooldown = minimumCooldown
+        self.validationLifetime = validationLifetime
+    }
+
+    public func validate(
+        _ request: WellnessSessionRequest,
+        for device: VerifiedWellnessDevice,
+        lastSessionEndedAt: Date?,
+        now: Date = .now
+    ) throws -> ValidatedWellnessSession {
+        guard request.deviceID == device.identity.deviceID else {
+            throw WellnessSessionValidationFailure.deviceMismatch
+        }
+        for capability in [
+            WellnessDeviceCapability.relaxationSession,
+            .sessionTimer,
+            .immediateStop
+        ] where !device.allowedCapabilities.contains(capability) {
+            throw WellnessSessionValidationFailure.missingCapability(capability)
+        }
+        guard durationRange.contains(request.durationMinutes) else {
+            throw WellnessSessionValidationFailure.durationOutOfRange
+        }
+        guard comfortLevelRange.contains(request.comfortLevel) else {
+            throw WellnessSessionValidationFailure.comfortLevelOutOfRange
+        }
+        if let lastSessionEndedAt {
+            let allowedAt = lastSessionEndedAt.addingTimeInterval(minimumCooldown)
+            guard now >= allowedAt else {
+                throw WellnessSessionValidationFailure.cooldownActive(until: allowedAt)
+            }
+        }
+        return ValidatedWellnessSession(
+            request: request,
+            validatedAt: now,
+            expiresAt: now.addingTimeInterval(validationLifetime)
+        )
+    }
+}

--- a/S2Y/Bluetooth/WellnessSessionAudit.swift
+++ b/S2Y/Bluetooth/WellnessSessionAudit.swift
@@ -1,0 +1,102 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+public struct WellnessSessionAuditRecord: Codable, Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let requestID: UUID
+    public let deviceID: UUID
+    public let purpose: WellnessSessionPurpose
+    public let requestedDurationMinutes: Int
+    public let comfortLevel: Int
+    public let origin: WellnessSessionOrigin
+    public let confirmedAt: Date
+    public var endedAt: Date?
+    public var stopReason: WellnessSessionStopReason?
+
+    public init(activeSession: ActiveWellnessSession) {
+        let request = activeSession.session.request
+        self.id = UUID()
+        self.requestID = request.id
+        self.deviceID = request.deviceID
+        self.purpose = request.purpose
+        self.requestedDurationMinutes = request.durationMinutes
+        self.comfortLevel = request.comfortLevel
+        self.origin = request.origin
+        self.confirmedAt = activeSession.confirmedAt
+        self.endedAt = nil
+        self.stopReason = nil
+    }
+
+    public mutating func finish(with stoppedSession: StoppedWellnessSession) {
+        guard stoppedSession.request.id == requestID else { return }
+        endedAt = stoppedSession.stoppedAt
+        stopReason = stoppedSession.reason
+    }
+}
+
+public struct WellnessSessionAuditLog: Codable, Sendable, Equatable {
+    public private(set) var records: [WellnessSessionAuditRecord]
+    public let maximumRecordCount: Int
+
+    public init(records: [WellnessSessionAuditRecord] = [], maximumRecordCount: Int = 100) {
+        self.maximumRecordCount = max(1, maximumRecordCount)
+        self.records = Array(records.prefix(self.maximumRecordCount))
+    }
+
+    public mutating func begin(_ activeSession: ActiveWellnessSession) {
+        records.insert(WellnessSessionAuditRecord(activeSession: activeSession), at: 0)
+        records = Array(records.prefix(maximumRecordCount))
+    }
+
+    public mutating func finish(_ stoppedSession: StoppedWellnessSession) {
+        guard let index = records.firstIndex(where: { $0.requestID == stoppedSession.request.id }) else {
+            return
+        }
+        records[index].finish(with: stoppedSession)
+    }
+}
+
+@MainActor
+final class WellnessSessionAuditStore: ObservableObject {
+    static let shared = WellnessSessionAuditStore()
+
+    @Published private(set) var log: WellnessSessionAuditLog
+
+    private let defaults: UserDefaults
+    private let storageKey = "wellnessSessionAudit.v1"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: storageKey),
+           let decoded = try? decoder.decode(WellnessSessionAuditLog.self, from: data) {
+            self.log = decoded
+        } else {
+            self.log = WellnessSessionAuditLog()
+        }
+    }
+
+    func begin(_ activeSession: ActiveWellnessSession) {
+        log.begin(activeSession)
+        persist()
+    }
+
+    func finish(_ stoppedSession: StoppedWellnessSession) {
+        log.finish(stoppedSession)
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? encoder.encode(log) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -911,6 +911,69 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(validated.request.origin, .assistantDraft)
     }
 
+    func testWellnessSessionCannotStartWithoutMatchingUserConfirmation() throws {
+        let validated = try validatedWellnessSession()
+        var controller = WellnessSessionController()
+        let confirmation = controller.prepare(validated, now: validated.validatedAt)
+
+        XCTAssertThrowsError(
+            try controller.confirm(confirmationID: UUID(), now: validated.validatedAt)
+        ) { error in
+            XCTAssertEqual(error as? WellnessSessionControlFailure, .confirmationMismatch)
+        }
+        XCTAssertEqual(controller.state, .awaitingConfirmation(confirmation))
+    }
+
+    func testWellnessSessionConfirmationExpires() throws {
+        let validated = try validatedWellnessSession()
+        var controller = WellnessSessionController()
+        let confirmation = controller.prepare(validated, now: validated.validatedAt)
+
+        XCTAssertThrowsError(
+            try controller.confirm(
+                confirmationID: confirmation.id,
+                now: validated.expiresAt.addingTimeInterval(1)
+            )
+        ) { error in
+            XCTAssertEqual(error as? WellnessSessionControlFailure, .confirmationExpired)
+        }
+    }
+
+    func testActiveWellnessSessionCanAlwaysStopLocally() throws {
+        let validated = try validatedWellnessSession()
+        var controller = WellnessSessionController()
+        let confirmation = controller.prepare(validated, now: validated.validatedAt)
+        _ = try controller.confirm(
+            confirmationID: confirmation.id,
+            now: validated.validatedAt.addingTimeInterval(1)
+        )
+        let stopTime = validated.validatedAt.addingTimeInterval(30)
+
+        let stopped = try controller.stopImmediately(reason: .safetyStop, now: stopTime)
+
+        XCTAssertEqual(stopped.reason, .safetyStop)
+        XCTAssertEqual(stopped.stoppedAt, stopTime)
+        XCTAssertEqual(controller.state, .stopped(stopped))
+    }
+
+    private func validatedWellnessSession() throws -> ValidatedWellnessSession {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
+        let deviceID = UUID()
+        let request = WellnessSessionRequest(
+            deviceID: deviceID,
+            purpose: .relaxation,
+            durationMinutes: 10,
+            comfortLevel: 1,
+            origin: .assistantDraft
+        )
+        return try WellnessSessionSafetyPolicy().validate(
+            request,
+            for: verifiedWellnessDevice(id: deviceID),
+            lastSessionEndedAt: nil,
+            now: now
+        )
+    }
+
     private func verifiedWellnessDevice(id: UUID) -> VerifiedWellnessDevice {
         let identity = WellnessDeviceIdentity(
             deviceID: id,

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -842,4 +842,87 @@ final class OmerMobileChatModelsTests: XCTestCase {
         let verified = try policy.verify(identity)
         XCTAssertEqual(verified.allowedCapabilities, [.relaxationSession, .immediateStop])
     }
+
+    func testWellnessSessionPolicyRejectsAssistantDraftOutsideLocalLimits() throws {
+        let deviceID = UUID()
+        let device = verifiedWellnessDevice(id: deviceID)
+        let request = WellnessSessionRequest(
+            deviceID: deviceID,
+            purpose: .relaxation,
+            durationMinutes: 45,
+            comfortLevel: 2,
+            origin: .assistantDraft
+        )
+
+        XCTAssertThrowsError(
+            try WellnessSessionSafetyPolicy().validate(request, for: device, lastSessionEndedAt: nil)
+        ) { error in
+            XCTAssertEqual(error as? WellnessSessionValidationFailure, .durationOutOfRange)
+        }
+    }
+
+    func testWellnessSessionPolicyEnforcesCooldown() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
+        let deviceID = UUID()
+        let device = verifiedWellnessDevice(id: deviceID)
+        let request = WellnessSessionRequest(
+            deviceID: deviceID,
+            purpose: .windDown,
+            durationMinutes: 10,
+            comfortLevel: 1,
+            origin: .userCreated
+        )
+        let lastEnd = now.addingTimeInterval(-30 * 60)
+
+        XCTAssertThrowsError(
+            try WellnessSessionSafetyPolicy().validate(
+                request,
+                for: device,
+                lastSessionEndedAt: lastEnd,
+                now: now
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? WellnessSessionValidationFailure,
+                .cooldownActive(until: lastEnd.addingTimeInterval(60 * 60))
+            )
+        }
+    }
+
+    func testWellnessSessionPolicyProducesShortLivedValidation() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
+        let deviceID = UUID()
+        let device = verifiedWellnessDevice(id: deviceID)
+        let request = WellnessSessionRequest(
+            deviceID: deviceID,
+            purpose: .mindfulBreak,
+            durationMinutes: 10,
+            comfortLevel: 2,
+            origin: .assistantDraft
+        )
+
+        let validated = try WellnessSessionSafetyPolicy().validate(
+            request,
+            for: device,
+            lastSessionEndedAt: now.addingTimeInterval(-2 * 60 * 60),
+            now: now
+        )
+        XCTAssertEqual(validated.expiresAt, now.addingTimeInterval(5 * 60))
+        XCTAssertEqual(validated.request.origin, .assistantDraft)
+    }
+
+    private func verifiedWellnessDevice(id: UUID) -> VerifiedWellnessDevice {
+        let identity = WellnessDeviceIdentity(
+            deviceID: id,
+            productIdentifier: "s2y-wellness-reference",
+            firmwareVersion: "1.0.0",
+            protocolVersion: 1,
+            reportedCapabilities: [.relaxationSession, .sessionTimer, .immediateStop],
+            manufacturerSignatureValidated: true
+        )
+        return VerifiedWellnessDevice(
+            identity: identity,
+            allowedCapabilities: identity.reportedCapabilities
+        )
+    }
 }

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -956,6 +956,48 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(controller.state, .stopped(stopped))
     }
 
+    func testWellnessSessionAuditRecordsUserVisibleFieldsWithoutHardwarePayload() throws {
+        let validated = try validatedWellnessSession()
+        let active = ActiveWellnessSession(
+            session: validated,
+            confirmedAt: validated.validatedAt,
+            scheduledEndAt: validated.validatedAt.addingTimeInterval(600)
+        )
+        var log = WellnessSessionAuditLog()
+        log.begin(active)
+        let stopped = StoppedWellnessSession(
+            request: validated.request,
+            stoppedAt: validated.validatedAt.addingTimeInterval(120),
+            reason: .userStopped
+        )
+        log.finish(stopped)
+
+        let record = try XCTUnwrap(log.records.first)
+        XCTAssertEqual(record.stopReason, .userStopped)
+        XCTAssertEqual(record.endedAt, stopped.stoppedAt)
+
+        let json = String(decoding: try encoder.encode(log), as: UTF8.self)
+        XCTAssertFalse(json.localizedCaseInsensitiveContains("amplitude"))
+        XCTAssertFalse(json.localizedCaseInsensitiveContains("frequency"))
+        XCTAssertFalse(json.localizedCaseInsensitiveContains("treatment"))
+    }
+
+    func testWellnessSessionAuditLogCapsLocalHistory() throws {
+        let validated = try validatedWellnessSession()
+        let active = ActiveWellnessSession(
+            session: validated,
+            confirmedAt: validated.validatedAt,
+            scheduledEndAt: validated.validatedAt.addingTimeInterval(600)
+        )
+        var log = WellnessSessionAuditLog(maximumRecordCount: 2)
+
+        log.begin(active)
+        log.begin(active)
+        log.begin(active)
+
+        XCTAssertEqual(log.records.count, 2)
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -785,4 +785,61 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(review.unrecordedCount, 6)
         XCTAssertEqual(review.adjustment, .considerSimplifying)
     }
+
+    func testWellnessDeviceTrustPolicyFailsClosedForUnknownIdentity() throws {
+        let identity = WellnessDeviceIdentity(
+            deviceID: UUID(),
+            productIdentifier: "unknown-device",
+            firmwareVersion: "1.0.0",
+            protocolVersion: 1,
+            reportedCapabilities: [.relaxationSession, .immediateStop],
+            manufacturerSignatureValidated: true
+        )
+        let policy = WellnessDeviceTrustPolicy(
+            supportedProductIdentifiers: ["s2y-wellness-reference"],
+            supportedProtocolVersions: 1 ... 1
+        )
+
+        XCTAssertThrowsError(try policy.verify(identity)) { error in
+            XCTAssertEqual(error as? WellnessDeviceTrustFailure, .unsupportedProduct)
+        }
+    }
+
+    func testWellnessDeviceTrustPolicyRequiresImmediateStopCapability() throws {
+        let identity = WellnessDeviceIdentity(
+            deviceID: UUID(),
+            productIdentifier: "s2y-wellness-reference",
+            firmwareVersion: "1.0.0",
+            protocolVersion: 1,
+            reportedCapabilities: [.relaxationSession],
+            manufacturerSignatureValidated: true
+        )
+        let policy = WellnessDeviceTrustPolicy(
+            supportedProductIdentifiers: ["s2y-wellness-reference"],
+            supportedProtocolVersions: 1 ... 1
+        )
+
+        XCTAssertThrowsError(try policy.verify(identity)) { error in
+            XCTAssertEqual(error as? WellnessDeviceTrustFailure, .missingImmediateStop)
+        }
+    }
+
+    func testWellnessDeviceTrustPolicyNarrowsReportedCapabilities() throws {
+        let identity = WellnessDeviceIdentity(
+            deviceID: UUID(),
+            productIdentifier: "s2y-wellness-reference",
+            firmwareVersion: "1.0.0",
+            protocolVersion: 1,
+            reportedCapabilities: [.relaxationSession, .levelAdjustment, .immediateStop],
+            manufacturerSignatureValidated: true
+        )
+        let policy = WellnessDeviceTrustPolicy(
+            supportedProductIdentifiers: ["s2y-wellness-reference"],
+            supportedProtocolVersions: 1 ... 1,
+            allowedCapabilities: [.relaxationSession, .immediateStop]
+        )
+
+        let verified = try policy.verify(identity)
+        XCTAssertEqual(verified.allowedCapabilities, [.relaxationSession, .immediateStop])
+    }
 }


### PR DESCRIPTION
## Summary
- HLT-021 verifies device identity, protocol version, and allowed capabilities with fail-closed rules
- HLT-022 applies fixed local duration, comfort-level, capability, cooldown, and expiry limits
- HLT-023 requires fresh user confirmation and keeps immediate stop entirely local
- HLT-024 stores a bounded local audit summary and clearly states that compatible wellness hardware is not yet configured

## Safety boundary
- does not implement a taVNS hardware protocol or stimulation payload
- does not allow Omer AI to start sessions or widen local limits
- does not record amplitude, frequency, treatment parameters, or raw Bluetooth payloads
- preserves the existing measurement-device / HealthKit path separately

## Validation
- all S2Y unit tests pass on the iPhone 16e simulator
- generic iOS Simulator build passes with signing disabled

## Stack
This PR is stacked on EPIC-H05 PR #35 and should be reviewed/merged after it.

Advances #12, #13, and #15.