### PR TITLE
EPIC-H07: add local safety escalation and clear boundaries

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -36,6 +36,12 @@ struct HealthAssistantSettingsView: View {
 
             Section {
                 Toggle("Share Health summary with Omer", isOn: $omerIncludeHealthContext)
+
+                NavigationLink {
+                    HealthSafetyActivityView()
+                } label: {
+                    Label("Safety Activity", systemImage: "shield.checkered")
+                }
             } header: {
                 Text("Privacy")
             } footer: {

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -444,7 +444,13 @@ struct HealthAssistantView: View {
         inputText = ""
         isInputFocused = false
         if let escalation = HealthSafetyTriage.evaluate(query) {
-            messages.append(ChatMessage(role: .assistant, content: escalation.userMessage))
+            messages.append(
+                ChatMessage(
+                    role: .assistant,
+                    content: escalation.userMessage,
+                    communicationKind: .urgentAction
+                )
+            )
             notice = AssistantNotice(
                 message: "This safety guidance was generated on this iPhone without contacting an AI provider.",
                 tone: .warning
@@ -589,7 +595,8 @@ struct HealthAssistantView: View {
             id: id,
             role: existingMessage.role,
             content: existingMessage.content + delta,
-            chartAttachment: existingMessage.chartAttachment
+            chartAttachment: existingMessage.chartAttachment,
+            communicationKind: existingMessage.communicationKind
         )
         streamTick += 1
     }
@@ -605,7 +612,8 @@ struct HealthAssistantView: View {
             id: id,
             role: existingMessage.role,
             content: content,
-            chartAttachment: existingMessage.chartAttachment
+            chartAttachment: existingMessage.chartAttachment,
+            communicationKind: existingMessage.communicationKind
         )
         streamTick += 1
     }
@@ -621,7 +629,8 @@ struct HealthAssistantView: View {
             id: id,
             role: existingMessage.role,
             content: existingMessage.content,
-            chartAttachment: attachment
+            chartAttachment: attachment,
+            communicationKind: .healthObservation
         )
         streamTick += 1
     }
@@ -757,6 +766,7 @@ struct ChatMessage: Identifiable, Sendable {
     let role: Role
     let content: String
     let chartAttachment: HealthChartAttachment?
+    let communicationKind: HealthCommunicationKind?
     
     enum Role {
         case user
@@ -767,12 +777,14 @@ struct ChatMessage: Identifiable, Sendable {
         id: UUID = UUID(),
         role: Role,
         content: String,
-        chartAttachment: HealthChartAttachment? = nil
+        chartAttachment: HealthChartAttachment? = nil,
+        communicationKind: HealthCommunicationKind? = nil
     ) {
         self.id = id
         self.role = role
         self.content = content
         self.chartAttachment = chartAttachment
+        self.communicationKind = communicationKind ?? (role == .assistant ? .wellnessGuidance : nil)
     }
 }
 
@@ -911,6 +923,15 @@ struct MessageBubble: View {
                     )
                     .foregroundColor(message.role == .user ? .white : .primary)
 
+                if let communicationKind = message.communicationKind {
+                    Label(communicationKind.title, systemImage: communicationKind.systemImage)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(communicationKind.tint)
+                    Text(communicationKind.disclosure)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
                 if let chartAttachment = message.chartAttachment {
                     VStack(alignment: .leading, spacing: 6) {
                         chart(attachment: chartAttachment)
@@ -991,6 +1012,24 @@ struct MessageBubble: View {
             .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
         case .paragraph:
             Text(block.content)
+        }
+    }
+}
+
+private extension HealthCommunicationKind {
+    var systemImage: String {
+        switch self {
+        case .healthObservation: "chart.xyaxis.line"
+        case .wellnessGuidance: "leaf"
+        case .urgentAction: "cross.case.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .healthObservation: .blue
+        case .wellnessGuidance: .green
+        case .urgentAction: .red
         }
     }
 }

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -439,10 +439,20 @@ struct HealthAssistantView: View {
 
         let userMessage = ChatMessage(role: .user, content: trimmedInput)
         messages.append(userMessage)
-        
+
         let query = trimmedInput
         inputText = ""
         isInputFocused = false
+        if let escalation = HealthSafetyTriage.evaluate(query) {
+            messages.append(ChatMessage(role: .assistant, content: escalation.userMessage))
+            notice = AssistantNotice(
+                message: "This safety guidance was generated on this iPhone without contacting an AI provider.",
+                tone: .warning
+            )
+            isProcessing = false
+            return
+        }
+
         isProcessing = true
         notice = nil
 

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -444,6 +444,7 @@ struct HealthAssistantView: View {
         inputText = ""
         isInputFocused = false
         if let escalation = HealthSafetyTriage.evaluate(query) {
+            HealthSafetyEventStore.shared.record(escalation)
             messages.append(
                 ChatMessage(
                     role: .assistant,

--- a/S2Y/HealthAssistant/HealthInterpretationPolicy.swift
+++ b/S2Y/HealthAssistant/HealthInterpretationPolicy.swift
@@ -8,6 +8,31 @@
 
 import Foundation
 
+enum HealthCommunicationKind: String, Codable, Sendable, Equatable {
+    case healthObservation
+    case wellnessGuidance
+    case urgentAction
+
+    var title: String {
+        switch self {
+        case .healthObservation: "Health data observation"
+        case .wellnessGuidance: "General wellness guidance"
+        case .urgentAction: "Urgent safety guidance"
+        }
+    }
+
+    var disclosure: String {
+        switch self {
+        case .healthObservation:
+            "Describes available data and coverage; it is not a medical conclusion."
+        case .wellnessGuidance:
+            "For general wellbeing and health management, not diagnosis or treatment."
+        case .urgentAction:
+            "Local safety guidance only; contact emergency or crisis services now."
+        }
+    }
+}
+
 enum HealthInterpretationPolicy {
     static let wellnessBoundary = "Health trends are wellness information, not a diagnosis or treatment recommendation."
 

--- a/S2Y/HealthAssistant/HealthSafetyEvent.swift
+++ b/S2Y/HealthAssistant/HealthSafetyEvent.swift
@@ -1,0 +1,130 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+public struct HealthSafetyEvent: Codable, Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let occurredAt: Date
+    public let level: HealthSafetyEscalationLevel
+    public let signalCategories: [String]
+    public let aiProviderContacted: Bool
+
+    public init(escalation: HealthSafetyEscalation, occurredAt: Date = .now) {
+        self.id = UUID()
+        self.occurredAt = occurredAt
+        self.level = escalation.level
+        self.signalCategories = escalation.signalCategories.sorted()
+        self.aiProviderContacted = false
+    }
+}
+
+public struct HealthSafetyEventLog: Codable, Sendable, Equatable {
+    public private(set) var events: [HealthSafetyEvent]
+    public let maximumEventCount: Int
+
+    public init(events: [HealthSafetyEvent] = [], maximumEventCount: Int = 50) {
+        self.maximumEventCount = max(1, maximumEventCount)
+        self.events = Array(events.prefix(self.maximumEventCount))
+    }
+
+    public mutating func record(_ event: HealthSafetyEvent) {
+        events.insert(event, at: 0)
+        events = Array(events.prefix(maximumEventCount))
+    }
+
+    public mutating func clear() {
+        events.removeAll()
+    }
+}
+
+@MainActor
+final class HealthSafetyEventStore: ObservableObject {
+    static let shared = HealthSafetyEventStore()
+
+    @Published private(set) var log: HealthSafetyEventLog
+
+    private let defaults: UserDefaults
+    private let storageKey = "healthSafetyEvents.v1"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: storageKey),
+           let decoded = try? decoder.decode(HealthSafetyEventLog.self, from: data) {
+            self.log = decoded
+        } else {
+            self.log = HealthSafetyEventLog()
+        }
+    }
+
+    func record(_ escalation: HealthSafetyEscalation, at date: Date = .now) {
+        log.record(HealthSafetyEvent(escalation: escalation, occurredAt: date))
+        persist()
+    }
+
+    func clear() {
+        log.clear()
+        defaults.removeObject(forKey: storageKey)
+    }
+
+    private func persist() {
+        guard let data = try? encoder.encode(log) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}
+
+struct HealthSafetyActivityView: View {
+    @StateObject private var store = HealthSafetyEventStore.shared
+
+    var body: some View {
+        List {
+            if store.log.events.isEmpty {
+                ContentUnavailableView(
+                    "No Safety Events",
+                    systemImage: "shield.checkered",
+                    description: Text("Urgent safety routing will be summarized here without saving your message text.")
+                )
+            } else {
+                Section("On this iPhone") {
+                    ForEach(store.log.events) { event in
+                        VStack(alignment: .leading, spacing: 5) {
+                            Label(event.level.displayName, systemImage: "shield.checkered")
+                                .font(.headline)
+                            Text(event.occurredAt, style: .date)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(event.signalCategories.joined(separator: ", "))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+
+                Section {
+                    Button("Clear Safety Activity", role: .destructive) {
+                        store.clear()
+                    }
+                }
+            }
+        }
+        .navigationTitle("Safety Activity")
+    }
+}
+
+private extension HealthSafetyEscalationLevel {
+    var displayName: String {
+        switch self {
+        case .emergency: "Emergency guidance shown"
+        case .selfHarmCrisis: "Crisis guidance shown"
+        }
+    }
+}

--- a/S2Y/HealthAssistant/HealthSafetyTriage.swift
+++ b/S2Y/HealthAssistant/HealthSafetyTriage.swift
@@ -1,0 +1,124 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public enum HealthSafetyEscalationLevel: String, Codable, Sendable, Equatable {
+    case emergency
+    case selfHarmCrisis
+}
+
+public struct HealthSafetyEscalation: Sendable, Equatable {
+    public let level: HealthSafetyEscalationLevel
+    public let signalCategories: Set<String>
+    public let userMessage: String
+
+    public init(
+        level: HealthSafetyEscalationLevel,
+        signalCategories: Set<String>,
+        userMessage: String
+    ) {
+        self.level = level
+        self.signalCategories = signalCategories
+        self.userMessage = userMessage
+    }
+}
+
+/// A small deterministic first-pass safety net that runs before any AI provider.
+/// It does not diagnose or infer risk from HealthKit values.
+public enum HealthSafetyTriage {
+    private struct Signal {
+        let category: String
+        let phrases: [String]
+    }
+
+    private static let emergencySignals = [
+        Signal(category: "breathing", phrases: [
+            "can't breathe", "cannot breathe", "severe difficulty breathing", "无法呼吸", "呼吸非常困难"
+        ]),
+        Signal(category: "chest-pain", phrases: [
+            "chest pain", "chest pressure", "胸痛", "胸口剧痛"
+        ]),
+        Signal(category: "stroke-signs", phrases: [
+            "face drooping", "slurred speech", "one-sided weakness", "半边无力", "口齿不清", "脸歪"
+        ]),
+        Signal(category: "unresponsive", phrases: [
+            "unconscious", "not waking up", "passed out and won't wake", "昏迷", "叫不醒"
+        ]),
+        Signal(category: "severe-bleeding", phrases: [
+            "severe bleeding", "bleeding won't stop", "大量出血", "止不住血"
+        ]),
+        Signal(category: "overdose", phrases: [
+            "overdose", "took too many pills", "药物过量", "吃了过量的药"
+        ])
+    ]
+
+    private static let selfHarmSignals = [
+        Signal(category: "self-harm", phrases: [
+            "kill myself", "end my life", "suicide", "hurt myself", "自杀", "不想活了", "伤害自己"
+        ])
+    ]
+
+    private static let negations = [
+        "no ", "not ", "don't ", "do not ", "without ", "denies ", "没有", "并无", "不是"
+    ]
+
+    private static let clauseBoundaries = [
+        " but ", " however ", ";", ".", ",", "但是", "但", "，", "。"
+    ]
+
+    public static func evaluate(_ text: String) -> HealthSafetyEscalation? {
+        let normalized = text
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .lowercased()
+
+        let selfHarmCategories = matchedCategories(in: normalized, signals: selfHarmSignals)
+        if !selfHarmCategories.isEmpty {
+            return HealthSafetyEscalation(
+                level: .selfHarmCrisis,
+                signalCategories: selfHarmCategories,
+                userMessage: "Your immediate safety matters. If you may act on these thoughts, call your local emergency number now. In the U.S. or Canada, call or text 988. If possible, move away from anything you could use to hurt yourself and contact someone you trust to stay with you."
+            )
+        }
+
+        let emergencyCategories = matchedCategories(in: normalized, signals: emergencySignals)
+        if !emergencyCategories.isEmpty {
+            return HealthSafetyEscalation(
+                level: .emergency,
+                signalCategories: emergencyCategories,
+                userMessage: "These symptoms may need urgent in-person help. Call your local emergency number now (911 in the U.S. or Canada). Do not drive yourself. If you can, ask someone nearby to stay with you and follow the dispatcher’s instructions."
+            )
+        }
+        return nil
+    }
+
+    private static func matchedCategories(in text: String, signals: [Signal]) -> Set<String> {
+        Set(signals.compactMap { signal in
+            signal.phrases.contains { phrase in
+                unnegatedRange(of: phrase, in: text) != nil
+            } ? signal.category : nil
+        })
+    }
+
+    private static func unnegatedRange(of phrase: String, in text: String) -> Range<String.Index>? {
+        var searchStart = text.startIndex
+        while searchStart < text.endIndex,
+              let range = text.range(of: phrase, range: searchStart ..< text.endIndex) {
+            let contextStart = text.index(range.lowerBound, offsetBy: -32, limitedBy: text.startIndex) ?? text.startIndex
+            let prefix = String(text[contextStart ..< range.lowerBound])
+            let clausePrefix = clauseBoundaries.reduce(prefix) { current, boundary in
+                current.components(separatedBy: boundary).last ?? current
+            }
+            if !negations.contains(where: clausePrefix.contains) {
+                return range
+            }
+            searchStart = range.upperBound
+        }
+        return nil
+    }
+}

--- a/S2Y/LLM/EnhancedHealthChatController.swift
+++ b/S2Y/LLM/EnhancedHealthChatController.swift
@@ -44,6 +44,7 @@ public final class EnhancedHealthChatController: ObservableObject {
         }
 
         if let escalation = HealthSafetyTriage.evaluate(message) {
+            HealthSafetyEventStore.shared.record(escalation)
             let response = EnhancedChatResponse(
                 content: escalation.userMessage,
                 contentCN: escalation.userMessage,

--- a/S2Y/LLM/EnhancedHealthChatController.swift
+++ b/S2Y/LLM/EnhancedHealthChatController.swift
@@ -42,6 +42,21 @@ public final class EnhancedHealthChatController: ObservableObject {
         defer {
             isProcessing = false
         }
+
+        if let escalation = HealthSafetyTriage.evaluate(message) {
+            let response = EnhancedChatResponse(
+                content: escalation.userMessage,
+                contentCN: escalation.userMessage,
+                source: .safetyEscalation,
+                confidence: 1,
+                structuredData: nil,
+                processingMetadata: ProcessingMetadata(
+                    safetyEscalationLevel: escalation.level
+                )
+            )
+            lastResponse = response
+            return response
+        }
         
         do {
             // Step 1: Check if clarification is needed
@@ -321,6 +336,7 @@ public struct EnhancedChatResponse {
         case healthOnly  // Health Intelligence only
         case clarification // Needs user clarification
         case fallback    // Error fallback
+        case safetyEscalation // Deterministic local emergency guidance
     }
 }
 
@@ -357,6 +373,7 @@ public struct ProcessingMetadata {
     public let contextUsed: Bool
     public let error: LLMError?
     public let fallbackUsed: Bool
+    public let safetyEscalationLevel: HealthSafetyEscalationLevel?
     
     public init(
         needsClarification: Bool = false,
@@ -365,7 +382,8 @@ public struct ProcessingMetadata {
         llmSource: LLMResponse.ResponseSource? = nil,
         contextUsed: Bool = false,
         error: LLMError? = nil,
-        fallbackUsed: Bool = false
+        fallbackUsed: Bool = false,
+        safetyEscalationLevel: HealthSafetyEscalationLevel? = nil
     ) {
         self.needsClarification = needsClarification
         self.clarificationReason = clarificationReason
@@ -374,6 +392,7 @@ public struct ProcessingMetadata {
         self.contextUsed = contextUsed
         self.error = error
         self.fallbackUsed = fallbackUsed
+        self.safetyEscalationLevel = safetyEscalationLevel
     }
 }
 

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1023,6 +1023,15 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertNil(HealthSafetyTriage.evaluate("我没有胸痛，只想查看步数趋势"))
     }
 
+    func testSafetyEscalationMetadataDoesNotClaimAIOrHealthAnalysis() {
+        let metadata = ProcessingMetadata(safetyEscalationLevel: .emergency)
+
+        XCTAssertEqual(metadata.safetyEscalationLevel, .emergency)
+        XCTAssertNil(metadata.llmSource)
+        XCTAssertFalse(metadata.healthAnalysisUsed)
+        XCTAssertFalse(metadata.contextUsed)
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1032,6 +1032,21 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertFalse(metadata.contextUsed)
     }
 
+    func testHealthCommunicationLayersKeepObservationAndGuidanceDistinct() {
+        let observation = ChatMessage(
+            role: .assistant,
+            content: "Seven observed days",
+            communicationKind: .healthObservation
+        )
+        let generalGuidance = ChatMessage(role: .assistant, content: "Consider a consistent bedtime")
+        let userMessage = ChatMessage(role: .user, content: "How was my sleep?")
+
+        XCTAssertEqual(observation.communicationKind, .healthObservation)
+        XCTAssertEqual(generalGuidance.communicationKind, .wellnessGuidance)
+        XCTAssertNil(userMessage.communicationKind)
+        XCTAssertTrue(HealthCommunicationKind.wellnessGuidance.disclosure.contains("not diagnosis"))
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1047,6 +1047,32 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(HealthCommunicationKind.wellnessGuidance.disclosure.contains("not diagnosis"))
     }
 
+    func testHealthSafetyAuditExcludesRawMessageAndProviderContact() throws {
+        let escalation = try XCTUnwrap(HealthSafetyTriage.evaluate("I have chest pain"))
+        let event = HealthSafetyEvent(escalation: escalation)
+        var log = HealthSafetyEventLog(maximumEventCount: 2)
+
+        log.record(event)
+        log.record(event)
+        log.record(event)
+
+        XCTAssertEqual(log.events.count, 2)
+        XCTAssertFalse(event.aiProviderContacted)
+        let json = String(decoding: try encoder.encode(log), as: UTF8.self)
+        XCTAssertFalse(json.localizedCaseInsensitiveContains("I have chest pain"))
+        XCTAssertTrue(json.contains("chest-pain"))
+    }
+
+    func testHealthSafetyAuditCanBeClearedLocally() throws {
+        let escalation = try XCTUnwrap(HealthSafetyTriage.evaluate("I have chest pain"))
+        var log = HealthSafetyEventLog()
+        log.record(HealthSafetyEvent(escalation: escalation))
+
+        log.clear()
+
+        XCTAssertTrue(log.events.isEmpty)
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -998,6 +998,31 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(log.records.count, 2)
     }
 
+    func testHealthSafetyTriageEscalatesEmergencySignalsWithoutDiagnosis() throws {
+        let escalation = try XCTUnwrap(
+            HealthSafetyTriage.evaluate("I have sudden chest pain and can't breathe")
+        )
+
+        XCTAssertEqual(escalation.level, .emergency)
+        XCTAssertEqual(escalation.signalCategories, ["breathing", "chest-pain"])
+        XCTAssertTrue(escalation.userMessage.contains("911"))
+        XCTAssertFalse(escalation.userMessage.localizedCaseInsensitiveContains("diagnosis"))
+    }
+
+    func testHealthSafetyTriageRecognizesChineseCrisisLanguage() throws {
+        let escalation = try XCTUnwrap(HealthSafetyTriage.evaluate("我不想活了，想伤害自己"))
+
+        XCTAssertEqual(escalation.level, .selfHarmCrisis)
+        XCTAssertEqual(escalation.signalCategories, ["self-harm"])
+        XCTAssertTrue(escalation.userMessage.contains("988"))
+    }
+
+    func testHealthSafetyTriageDoesNotEscalateNegatedOrRoutineQueries() {
+        XCTAssertNil(HealthSafetyTriage.evaluate("I do not have chest pain; how was my sleep?"))
+        XCTAssertNil(HealthSafetyTriage.evaluate("How has my resting heart rate changed this week?"))
+        XCTAssertNil(HealthSafetyTriage.evaluate("我没有胸痛，只想查看步数趋势"))
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()


### PR DESCRIPTION
## Summary
- HLT-025 detects explicit emergency and self-harm crisis language locally in English and Chinese
- HLT-026 routes urgent messages before HealthKit, Apple AI, or Omer can be contacted
- HLT-027 labels responses as health-data observations, general wellness guidance, or urgent safety guidance
- HLT-028 keeps a bounded, user-clearable local safety activity log without storing message text

## Privacy and compliance boundary
- deterministic routing does not diagnose or infer risk from HealthKit values
- urgent message text is not sent to an AI provider
- audit records contain only timestamp, escalation level, signal categories, and provider-contact status
- responses continue to distinguish health management from diagnosis and treatment

## Validation
- all S2Y unit tests pass on the iPhone 16e simulator
- generic iOS Simulator build passes with signing disabled

## Stack
This PR is stacked on EPIC-H06 PR #36 and should be reviewed/merged after it.

Advances #12, #14, #15, and #19.