### PR TITLE
EPIC-H08: require granular consent for health sharing

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -13,7 +13,8 @@ struct HealthAssistantSettingsView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var showingCacheClearedAlert = false
-    @AppStorage(StorageKeys.omerIncludeHealthContext) private var omerIncludeHealthContext = true
+    @State private var showingChatCacheClearedAlert = false
+    @StateObject private var sharingConsentStore = HealthSharingConsentStore.shared
 
     init(showsDismissButton: Bool = false) {
         self.showsDismissButton = showsDismissButton
@@ -35,7 +36,20 @@ struct HealthAssistantSettingsView: View {
             }
 
             Section {
-                Toggle("Share Health summary with Omer", isOn: $omerIncludeHealthContext)
+                Toggle(
+                    "Send questions to Omer Online",
+                    isOn: consentBinding(for: .omerChatText)
+                )
+
+                Toggle(
+                    "Share relevant Health summary",
+                    isOn: consentBinding(for: .relevantHealthSummary)
+                )
+
+                Toggle(
+                    "Sync on-device conversations",
+                    isOn: consentBinding(for: .onDeviceConversationSync)
+                )
 
                 NavigationLink {
                     HealthSafetyActivityView()
@@ -45,7 +59,10 @@ struct HealthAssistantSettingsView: View {
             } header: {
                 Text("Privacy")
             } footer: {
-                Text("When Omer Online is selected, this allows a short summary of relevant Health data to be included with your question. On-device analysis stays on your iPhone, while chat history may still sync to your S2Y account.")
+                Text(
+                    "Each sharing choice is independent and can be withdrawn immediately. "
+                        + "On-device analysis stays on this iPhone unless conversation sync is enabled."
+                )
             }
 
             Section("Plan") {
@@ -57,6 +74,13 @@ struct HealthAssistantSettingsView: View {
             }
 
             Section {
+                Button("Clear locally saved chat history", role: .destructive) {
+                    Task {
+                        await OmerChatService.shared.clearLocalChatCache()
+                        showingChatCacheClearedAlert = true
+                    }
+                }
+
                 Button("Clear Health data cache", role: .destructive) {
                     HealthKitCache.shared.clearAll()
                     showingCacheClearedAlert = true
@@ -83,5 +107,24 @@ struct HealthAssistantSettingsView: View {
         } message: {
             Text("Cached Health summaries were removed from this iPhone.")
         }
+        .alert("Local chat history cleared", isPresented: $showingChatCacheClearedAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Locally saved chat copies were removed. This does not delete conversations already synced to your S2Y account.")
+        }
+    }
+
+    private func consentBinding(for scope: HealthSharingScope) -> Binding<Bool> {
+        Binding(
+            get: {
+                HealthSharingConsentPolicy.permits(
+                    scope,
+                    authorization: sharingConsentStore.authorization
+                )
+            },
+            set: { granted in
+                sharingConsentStore.set(scope, granted: granted)
+            }
+        )
     }
 }

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -483,19 +483,38 @@ struct HealthAssistantView: View {
                 }
                 if let assistantText = messages.first(where: { $0.id == assistantPlaceholder.id })?.content,
                    !assistantText.isEmpty {
+                    let authorization = HealthSharingConsentStore.shared.authorization
                     do {
-                        _ = try await omerChatService.syncOnDeviceExchange(
+                        try await omerChatService.saveOnDeviceExchangeLocally(
                             userMessageID: userMessage.id,
                             userText: query,
                             assistantMessageID: assistantPlaceholder.id,
                             assistantText: assistantText
                         )
                     } catch {
-                        logger.error("On-device chat sync failed: \(error.localizedDescription)")
+                        logger.error("Local on-device chat save failed: \(error.localizedDescription)")
                         notice = AssistantNotice(
-                            message: "The answer is available on this iPhone, but could not sync to your S2Y history yet.",
+                            message: "The answer is visible now, but could not be added to local history.",
                             tone: .warning
                         )
+                    }
+
+                    if HealthSharingConsentPolicy.permits(.onDeviceConversationSync, authorization: authorization) {
+                        do {
+                            _ = try await omerChatService.syncOnDeviceExchange(
+                                userMessageID: userMessage.id,
+                                userText: query,
+                                assistantMessageID: assistantPlaceholder.id,
+                                assistantText: assistantText,
+                                authorization: authorization
+                            )
+                        } catch {
+                            logger.error("On-device chat sync failed: \(error.localizedDescription)")
+                            notice = AssistantNotice(
+                                message: "The answer is saved on this iPhone, but could not sync to your S2Y account yet.",
+                                tone: .warning
+                            )
+                        }
                     }
                 }
                 onHistoryChanged()
@@ -532,12 +551,19 @@ struct HealthAssistantView: View {
         do {
             try await omerChatService.sendMessage(
                 message: query,
+                authorization: HealthSharingConsentStore.shared.authorization,
                 includeHealthContext: omerIncludeHealthContext
             ) { event in
                 Task { @MainActor in
                     self.handleOmerEvent(event, assistantMessageID: assistantMessageID)
                 }
             }
+        } catch let error as HealthSharingConsentFailure {
+            updateAssistantMessage(
+                id: assistantMessageID,
+                content: error.localizedDescription
+            )
+            notice = AssistantNotice(message: error.localizedDescription, tone: .warning)
         } catch {
             let underlyingError = error as NSError
             logger.error(

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -87,7 +87,6 @@ struct HealthAssistantView: View {
     @State private var availableSuggestionMetrics: Set<HealthKitService.MetricKind> = []
     @State private var didLoadSuggestionAvailability = false
     @FocusState private var isInputFocused: Bool
-    @AppStorage(StorageKeys.omerIncludeHealthContext) private var omerIncludeHealthContext = true
     @AppStorage(StorageKeys.healthAssistantAIMode) private var aiModeRawValue = AssistantAIMode.onDevice.rawValue
 
     private let newChatRequestID: UUID
@@ -468,7 +467,7 @@ struct HealthAssistantView: View {
 
         let healthContext = await OmerHealthContextBuilder.buildSummary(
             for: query,
-            includeHealthContext: omerIncludeHealthContext
+            includeHealthContext: selectedAIMode == .onDevice
         )
         let chartAttachment = await HealthChatVisualizationLoader.load(for: query)
         updateAssistantAttachment(id: assistantPlaceholder.id, attachment: chartAttachment)
@@ -552,7 +551,7 @@ struct HealthAssistantView: View {
             try await omerChatService.sendMessage(
                 message: query,
                 authorization: HealthSharingConsentStore.shared.authorization,
-                includeHealthContext: omerIncludeHealthContext
+                includeHealthContext: true
             ) { event in
                 Task { @MainActor in
                     self.handleOmerEvent(event, assistantMessageID: assistantMessageID)

--- a/S2Y/HealthAssistant/HealthSharingConsent.swift
+++ b/S2Y/HealthAssistant/HealthSharingConsent.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public enum HealthSharingScope: String, Codable, Sendable, CaseIterable {
+    /// The question a user explicitly sends while Omer Online is selected.
+    case omerChatText
+    /// A short, relevant summary derived from Health data.
+    case relevantHealthSummary
+    /// User and assistant text produced during an on-device conversation.
+    case onDeviceConversationSync
+}
+
+public struct HealthSharingAuthorization: Codable, Sendable, Equatable {
+    public var grantedScopes: Set<HealthSharingScope>
+
+    public init(grantedScopes: Set<HealthSharingScope> = []) {
+        self.grantedScopes = grantedScopes
+    }
+}
+
+public enum HealthSharingDecision: Sendable, Equatable {
+    case allowed
+    case denied(missingScopes: Set<HealthSharingScope>)
+}
+
+/// Default-deny policy for every payload that can leave the iPhone.
+public enum HealthSharingConsentPolicy {
+    public static func decision(
+        requestedScopes: Set<HealthSharingScope>,
+        authorization: HealthSharingAuthorization
+    ) -> HealthSharingDecision {
+        let missing = requestedScopes.subtracting(authorization.grantedScopes)
+        return missing.isEmpty ? .allowed : .denied(missingScopes: missing)
+    }
+
+    public static func permits(
+        _ scope: HealthSharingScope,
+        authorization: HealthSharingAuthorization
+    ) -> Bool {
+        decision(requestedScopes: [scope], authorization: authorization) == .allowed
+    }
+}

--- a/S2Y/HealthAssistant/HealthSharingConsent.swift
+++ b/S2Y/HealthAssistant/HealthSharingConsent.swift
@@ -31,6 +31,26 @@ public enum HealthSharingDecision: Sendable, Equatable {
     case denied(missingScopes: Set<HealthSharingScope>)
 }
 
+public struct HealthSharingConsentFailure: LocalizedError, Sendable, Equatable {
+    public let missingScopes: Set<HealthSharingScope>
+
+    public var errorDescription: String? {
+        "Review Health Assistant privacy settings before sharing: "
+            + missingScopes.map(\.displayName).sorted().joined(separator: ", ")
+            + "."
+    }
+}
+
+private extension HealthSharingScope {
+    var displayName: String {
+        switch self {
+        case .omerChatText: "Omer chat text"
+        case .relevantHealthSummary: "relevant Health summary"
+        case .onDeviceConversationSync: "on-device conversation sync"
+        }
+    }
+}
+
 /// Default-deny policy for every payload that can leave the iPhone.
 public enum HealthSharingConsentPolicy {
     public static let currentVersion = "2026-08-12"
@@ -48,6 +68,18 @@ public enum HealthSharingConsentPolicy {
         authorization: HealthSharingAuthorization
     ) -> Bool {
         decision(requestedScopes: [scope], authorization: authorization) == .allowed
+    }
+
+    public static func require(
+        _ scopes: Set<HealthSharingScope>,
+        authorization: HealthSharingAuthorization
+    ) throws {
+        if case let .denied(missingScopes) = decision(
+            requestedScopes: scopes,
+            authorization: authorization
+        ) {
+            throw HealthSharingConsentFailure(missingScopes: missingScopes)
+        }
     }
 }
 

--- a/S2Y/HealthAssistant/HealthSharingConsent.swift
+++ b/S2Y/HealthAssistant/HealthSharingConsent.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import SwiftUI
 
-public enum HealthSharingScope: String, Codable, Sendable, CaseIterable {
+public enum HealthSharingScope: String, Codable, Sendable, CaseIterable, Hashable {
     /// The question a user explicitly sends while Omer Online is selected.
     case omerChatText
     /// A short, relevant summary derived from Health data.
@@ -32,6 +33,8 @@ public enum HealthSharingDecision: Sendable, Equatable {
 
 /// Default-deny policy for every payload that can leave the iPhone.
 public enum HealthSharingConsentPolicy {
+    public static let currentVersion = "2026-08-12"
+
     public static func decision(
         requestedScopes: Set<HealthSharingScope>,
         authorization: HealthSharingAuthorization
@@ -45,5 +48,99 @@ public enum HealthSharingConsentPolicy {
         authorization: HealthSharingAuthorization
     ) -> Bool {
         decision(requestedScopes: [scope], authorization: authorization) == .allowed
+    }
+}
+
+public enum HealthSharingConsentChange: String, Codable, Sendable, Equatable {
+    case granted
+    case revoked
+}
+
+public struct HealthSharingConsentReceipt: Codable, Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let policyVersion: String
+    public let change: HealthSharingConsentChange
+    public let changedScopes: Set<HealthSharingScope>
+    public let resultingAuthorization: HealthSharingAuthorization
+    public let recordedAt: Date
+}
+
+public struct HealthSharingConsentLedger: Codable, Sendable, Equatable {
+    public private(set) var receipts: [HealthSharingConsentReceipt]
+    public let maximumReceiptCount: Int
+
+    public init(receipts: [HealthSharingConsentReceipt] = [], maximumReceiptCount: Int = 20) {
+        self.maximumReceiptCount = max(1, maximumReceiptCount)
+        self.receipts = Array(receipts.prefix(self.maximumReceiptCount))
+    }
+
+    public func authorization(policyVersion: String = HealthSharingConsentPolicy.currentVersion) -> HealthSharingAuthorization {
+        guard let latest = receipts.first, latest.policyVersion == policyVersion else {
+            return HealthSharingAuthorization()
+        }
+        return latest.resultingAuthorization
+    }
+
+    @discardableResult
+    public mutating func apply(
+        _ change: HealthSharingConsentChange,
+        scopes: Set<HealthSharingScope>,
+        policyVersion: String = HealthSharingConsentPolicy.currentVersion,
+        at date: Date = .now
+    ) -> HealthSharingConsentReceipt {
+        var resulting = authorization(policyVersion: policyVersion)
+        switch change {
+        case .granted:
+            resulting.grantedScopes.formUnion(scopes)
+        case .revoked:
+            resulting.grantedScopes.subtract(scopes)
+        }
+        let receipt = HealthSharingConsentReceipt(
+            id: UUID(),
+            policyVersion: policyVersion,
+            change: change,
+            changedScopes: scopes,
+            resultingAuthorization: resulting,
+            recordedAt: date
+        )
+        receipts.insert(receipt, at: 0)
+        receipts = Array(receipts.prefix(maximumReceiptCount))
+        return receipt
+    }
+}
+
+@MainActor
+final class HealthSharingConsentStore: ObservableObject {
+    static let shared = HealthSharingConsentStore()
+
+    @Published private(set) var ledger: HealthSharingConsentLedger
+
+    private let defaults: UserDefaults
+    private let storageKey = "healthSharingConsent.v1"
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: storageKey),
+           let decoded = try? decoder.decode(HealthSharingConsentLedger.self, from: data) {
+            self.ledger = decoded
+        } else {
+            self.ledger = HealthSharingConsentLedger()
+        }
+    }
+
+    var authorization: HealthSharingAuthorization {
+        ledger.authorization()
+    }
+
+    func set(_ scope: HealthSharingScope, granted: Bool, at date: Date = .now) {
+        ledger.apply(granted ? .granted : .revoked, scopes: [scope], at: date)
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? encoder.encode(ledger) else { return }
+        defaults.set(data, forKey: storageKey)
     }
 }

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -190,6 +190,20 @@ actor OmerChatService {
         await sessionStore.saveLastChatId(nil, sessionKey: sessionKey(for: serviceURL))
     }
 
+    func clearLocalChatCache() async {
+        chatCache = OmerChatCacheSnapshot(chats: [], details: [])
+        if FileManager.default.fileExists(atPath: cacheURL.path) {
+            do {
+                try FileManager.default.removeItem(at: cacheURL)
+            } catch {
+                logger.error("Failed to clear local chat cache: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        if let serviceURL = try? configuredServiceURL() {
+            await sessionStore.saveLastChatId(nil, sessionKey: sessionKey(for: serviceURL))
+        }
+    }
+
     func syncOnDeviceExchange(
         userMessageID: UUID,
         userText: String,

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -34,16 +34,21 @@ actor OmerChatService {
 
     func sendMessage(
         message: String,
+        authorization: HealthSharingAuthorization,
         includeHealthContext: Bool,
         onEvent: @escaping @Sendable (OmerChatStreamEvent) -> Void
     ) async throws {
+        try HealthSharingConsentPolicy.require([.omerChatText], authorization: authorization)
         let serviceURL = try configuredServiceURL()
         let sessionKey = sessionKey(for: serviceURL)
         let conversationID = await existingOrNewConversationID(sessionKey: sessionKey)
         let requestID = UUID()
         let healthContext = await OmerHealthContextBuilder.buildSummary(
             for: message,
-            includeHealthContext: includeHealthContext
+            includeHealthContext: includeHealthContext && HealthSharingConsentPolicy.permits(
+                .relevantHealthSummary,
+                authorization: authorization
+            )
         )
         let body = OmerMobileChatRequest(
             requestId: requestID,
@@ -189,8 +194,10 @@ actor OmerChatService {
         userMessageID: UUID,
         userText: String,
         assistantMessageID: UUID,
-        assistantText: String
+        assistantText: String,
+        authorization: HealthSharingAuthorization
     ) async throws -> OmerLocalChatSyncResponse {
+        try HealthSharingConsentPolicy.require([.onDeviceConversationSync], authorization: authorization)
         let serviceURL = try configuredServiceURL()
         let key = sessionKey(for: serviceURL)
         let conversationID = await existingOrNewConversationID(sessionKey: key)
@@ -220,6 +227,26 @@ actor OmerChatService {
         )
         await sessionStore.saveLastChatId(response.conversationId.uuidString, sessionKey: key)
         return response
+    }
+
+    func saveOnDeviceExchangeLocally(
+        userMessageID: UUID,
+        userText: String,
+        assistantMessageID: UUID,
+        assistantText: String
+    ) async throws {
+        let serviceURL = try configuredServiceURL()
+        let key = sessionKey(for: serviceURL)
+        let conversationID = await existingOrNewConversationID(sessionKey: key)
+        cacheExchange(
+            conversationID: conversationID,
+            userMessageID: userMessageID,
+            userText: userText,
+            assistantMessageID: assistantMessageID,
+            assistantText: assistantText,
+            visibility: "private-local"
+        )
+        await sessionStore.saveLastChatId(conversationID.uuidString, sessionKey: key)
     }
 
     private func cacheExchange(

--- a/S2Y/SharedContext/StorageKeys.swift
+++ b/S2Y/SharedContext/StorageKeys.swift
@@ -32,8 +32,6 @@ enum StorageKeys {
     static let cloudflareGatewayURL = "cf.gateway-url"
     /// Device-level override for the Cloudflare AI model path. Empty = bundled default.
     static let cloudflareModelPath = "cf.model-path"
-    /// Whether Health Assistant should attach summarized health context to Omer requests.
-    static let omerIncludeHealthContext = "omer.include-health-context"
     /// User-selected Health Assistant inference route: on-device Apple AI or Omer online.
     static let healthAssistantAIMode = "health-assistant.ai-mode"
     /// Enable or disable voice features globally

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1127,6 +1127,25 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(ledger.receipts.count, 2)
     }
 
+    func testHealthSharingConsentRequirementReportsOnlyMissingScopes() throws {
+        let authorization = HealthSharingAuthorization(grantedScopes: [.omerChatText])
+
+        XCTAssertNoThrow(
+            try HealthSharingConsentPolicy.require([.omerChatText], authorization: authorization)
+        )
+        XCTAssertThrowsError(
+            try HealthSharingConsentPolicy.require(
+                [.omerChatText, .relevantHealthSummary],
+                authorization: authorization
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? HealthSharingConsentFailure,
+                HealthSharingConsentFailure(missingScopes: [.relevantHealthSummary])
+            )
+        }
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1073,6 +1073,29 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(log.events.isEmpty)
     }
 
+    func testHealthSharingConsentDefaultsToDenyForEveryScope() {
+        let authorization = HealthSharingAuthorization()
+
+        for scope in HealthSharingScope.allCases {
+            XCTAssertFalse(HealthSharingConsentPolicy.permits(scope, authorization: authorization))
+        }
+    }
+
+    func testHealthSharingScopesAreGrantedIndependently() {
+        let authorization = HealthSharingAuthorization(grantedScopes: [.omerChatText])
+
+        XCTAssertTrue(HealthSharingConsentPolicy.permits(.omerChatText, authorization: authorization))
+        XCTAssertFalse(HealthSharingConsentPolicy.permits(.relevantHealthSummary, authorization: authorization))
+        XCTAssertFalse(HealthSharingConsentPolicy.permits(.onDeviceConversationSync, authorization: authorization))
+        XCTAssertEqual(
+            HealthSharingConsentPolicy.decision(
+                requestedScopes: [.omerChatText, .relevantHealthSummary],
+                authorization: authorization
+            ),
+            .denied(missingScopes: [.relevantHealthSummary])
+        )
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1096,6 +1096,37 @@ final class OmerMobileChatModelsTests: XCTestCase {
         )
     }
 
+    func testHealthSharingConsentReceiptSupportsImmediateRevocation() {
+        var ledger = HealthSharingConsentLedger()
+        ledger.apply(.granted, scopes: [.omerChatText, .relevantHealthSummary])
+        ledger.apply(.revoked, scopes: [.relevantHealthSummary])
+
+        let authorization = ledger.authorization()
+        XCTAssertTrue(authorization.grantedScopes.contains(.omerChatText))
+        XCTAssertFalse(authorization.grantedScopes.contains(.relevantHealthSummary))
+        XCTAssertEqual(ledger.receipts.first?.change, .revoked)
+    }
+
+    func testHealthSharingConsentDoesNotCarryAcrossPolicyVersions() {
+        var ledger = HealthSharingConsentLedger()
+        ledger.apply(
+            .granted,
+            scopes: [.omerChatText],
+            policyVersion: "previous-version"
+        )
+
+        XCTAssertTrue(ledger.authorization().grantedScopes.isEmpty)
+    }
+
+    func testHealthSharingConsentLedgerBoundsReceiptHistory() {
+        var ledger = HealthSharingConsentLedger(maximumReceiptCount: 2)
+        ledger.apply(.granted, scopes: [.omerChatText])
+        ledger.apply(.granted, scopes: [.relevantHealthSummary])
+        ledger.apply(.revoked, scopes: [.omerChatText])
+
+        XCTAssertEqual(ledger.receipts.count, 2)
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1146,6 +1146,18 @@ final class OmerMobileChatModelsTests: XCTestCase {
         }
     }
 
+    func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {
+        var ledger = HealthSharingConsentLedger()
+        ledger.apply(.granted, scopes: [.omerChatText, .onDeviceConversationSync])
+        ledger.apply(.revoked, scopes: [.onDeviceConversationSync])
+
+        let authorization = ledger.authorization()
+        XCTAssertTrue(HealthSharingConsentPolicy.permits(.omerChatText, authorization: authorization))
+        XCTAssertFalse(
+            HealthSharingConsentPolicy.permits(.onDeviceConversationSync, authorization: authorization)
+        )
+    }
+
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {
         let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T20:00:00Z"))
         let deviceID = UUID()


### PR DESCRIPTION
## Summary
- HLT-029 separates Omer question text, relevant Health summaries, and on-device conversation sync into independent scopes
- HLT-030 stores versioned, immediately revocable local consent receipts and defaults to deny after a policy-version change
- HLT-031 enforces consent at the Omer service boundary while preserving on-device-only chat history
- HLT-032 gives users three plain-language controls and a local chat-history deletion action

## Privacy boundary
- all outbound scopes default to denied
- Health summary sharing is independently checked even when Omer chat text is allowed
- on-device conversations remain saved locally when cloud sync is not permitted
- revocation takes effect before the next network request
- clearing local chat history does not claim to delete already-synced server data

## Validation
- all S2Y unit tests pass on the iPhone 16e simulator
- generic iOS Simulator build passes with signing disabled

## Stack
This PR is stacked on EPIC-H07 PR #37 and should be reviewed/merged after it.

Advances #14, #15, and #19.