### PR TITLE
EPIC-H10: local-first wellbeing check-ins

### DIFF
--- a/S2Y/CheckIn/WellbeingCheckIn.swift
+++ b/S2Y/CheckIn/WellbeingCheckIn.swift
@@ -149,3 +149,47 @@ public enum WellbeingCheckInSnapshotError: LocalizedError, Sendable, Equatable {
         "The completed wellbeing check-in could not be summarized."
     }
 }
+
+public enum WellbeingCheckInContextBuilder {
+    public static func build(
+        from snapshots: [WellbeingCheckInSnapshot],
+        maximumSnapshotCount: Int = 3,
+        maximumCharacterCount: Int = 1_200
+    ) -> String? {
+        let snapshotLimit = max(1, maximumSnapshotCount)
+        let characterLimit = max(1, maximumCharacterCount)
+        var lines: [String] = []
+
+        for snapshot in snapshots
+            .sorted(by: { $0.recordedAt > $1.recordedAt })
+            .prefix(snapshotLimit) {
+            var fields = [
+                "date=\(snapshot.recordedAt.formatted(.iso8601.year().month().day()))"
+            ]
+            append("overall", snapshot.overallWellbeing, to: &fields)
+            append("energy", snapshot.energyLevel, to: &fields)
+            append("sleep", snapshot.sleepQuality, to: &fields)
+            append("stress", snapshot.stressLevel, to: &fields)
+            append("mood", snapshot.mood, to: &fields)
+            if !snapshot.reportedSymptoms.isEmpty {
+                fields.append("symptoms=\(snapshot.reportedSymptoms.joined(separator: ","))")
+            }
+            append("goal", snapshot.goalFocus, to: &fields)
+
+            let line = fields.joined(separator: "; ")
+            let candidate = (lines + [line]).joined(separator: "\n")
+            guard candidate.count <= characterLimit else {
+                break
+            }
+            lines.append(line)
+        }
+
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
+    }
+
+    private static func append(_ label: String, _ value: String?, to fields: inout [String]) {
+        if let value {
+            fields.append("\(label)=\(value)")
+        }
+    }
+}

--- a/S2Y/CheckIn/WellbeingCheckIn.swift
+++ b/S2Y/CheckIn/WellbeingCheckIn.swift
@@ -1,0 +1,151 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public struct WellbeingCheckInSnapshot: Codable, Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let recordedAt: Date
+    public let questionnaireIdentifier: String
+    public let overallWellbeing: String?
+    public let energyLevel: String?
+    public let sleepQuality: String?
+    public let sleepHours: Double?
+    public let stressLevel: String?
+    public let physicalActivity: String?
+    public let mood: String?
+    public let reportedSymptoms: [String]
+    public let goalFocus: String?
+
+    public init(
+        id: UUID = UUID(),
+        recordedAt: Date = .now,
+        questionnaireIdentifier: String,
+        overallWellbeing: String? = nil,
+        energyLevel: String? = nil,
+        sleepQuality: String? = nil,
+        sleepHours: Double? = nil,
+        stressLevel: String? = nil,
+        physicalActivity: String? = nil,
+        mood: String? = nil,
+        reportedSymptoms: [String] = [],
+        goalFocus: String? = nil
+    ) {
+        self.id = id
+        self.recordedAt = recordedAt
+        self.questionnaireIdentifier = Self.sanitized(questionnaireIdentifier, limit: 80)
+        self.overallWellbeing = Self.sanitizedOptional(overallWellbeing)
+        self.energyLevel = Self.sanitizedOptional(energyLevel)
+        self.sleepQuality = Self.sanitizedOptional(sleepQuality)
+        self.sleepHours = sleepHours.flatMap { (0...24).contains($0) ? $0 : nil }
+        self.stressLevel = Self.sanitizedOptional(stressLevel)
+        self.physicalActivity = Self.sanitizedOptional(physicalActivity)
+        self.mood = Self.sanitizedOptional(mood)
+        self.reportedSymptoms = Array(
+            reportedSymptoms
+                .map { Self.sanitized($0, limit: 80) }
+                .filter { !$0.isEmpty }
+                .prefix(8)
+        )
+        self.goalFocus = Self.sanitizedOptional(goalFocus)
+    }
+
+    private static func sanitizedOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let result = sanitized(value, limit: 80)
+        return result.isEmpty ? nil : result
+    }
+
+    private static func sanitized(_ value: String, limit: Int) -> String {
+        String(
+            value
+                .split(whereSeparator: \.isWhitespace)
+                .joined(separator: " ")
+                .prefix(limit)
+        )
+    }
+}
+
+public enum WellbeingCheckInSnapshotBuilder {
+    public static func build(
+        responseData: Data,
+        questionnaireIdentifier: String,
+        id: UUID = UUID(),
+        recordedAt: Date = .now
+    ) throws -> WellbeingCheckInSnapshot {
+        let object = try JSONSerialization.jsonObject(with: responseData)
+        guard let response = object as? [String: Any] else {
+            throw WellbeingCheckInSnapshotError.invalidResponse
+        }
+        let answers = flattenedAnswers(from: response["item"])
+
+        return WellbeingCheckInSnapshot(
+            id: id,
+            recordedAt: recordedAt,
+            questionnaireIdentifier: questionnaireIdentifier,
+            overallWellbeing: answers["overall-wellness"]?.first,
+            energyLevel: answers["energy-level"]?.first,
+            sleepQuality: answers["sleep-quality"]?.first,
+            sleepHours: answers["sleep-hours"]?.first.flatMap(Double.init),
+            stressLevel: answers["stress-level"]?.first,
+            physicalActivity: answers["physical-activity"]?.first,
+            mood: answers["mood"]?.first,
+            reportedSymptoms: answers["symptoms"] ?? [],
+            goalFocus: answers["goals-today"]?.first
+        )
+    }
+
+    private static func flattenedAnswers(from rawItems: Any?) -> [String: [String]] {
+        guard let items = rawItems as? [[String: Any]] else {
+            return [:]
+        }
+        var result: [String: [String]] = [:]
+        for item in items {
+            if let linkID = item["linkId"] as? String {
+                result[linkID, default: []].append(contentsOf: answerValues(from: item["answer"]))
+            }
+            let nested = flattenedAnswers(from: item["item"])
+            for (linkID, values) in nested {
+                result[linkID, default: []].append(contentsOf: values)
+            }
+        }
+        return result
+    }
+
+    private static func answerValues(from rawAnswers: Any?) -> [String] {
+        guard let answers = rawAnswers as? [[String: Any]] else {
+            return []
+        }
+        return answers.compactMap { answer in
+            if let coding = answer["valueCoding"] as? [String: Any] {
+                return coding["code"] as? String
+            }
+            if let string = answer["valueString"] as? String {
+                return string
+            }
+            if let decimal = answer["valueDecimal"] as? NSNumber {
+                return decimal.stringValue
+            }
+            if let integer = answer["valueInteger"] as? NSNumber {
+                return integer.stringValue
+            }
+            if let boolean = answer["valueBoolean"] as? Bool {
+                return boolean ? "true" : "false"
+            }
+            return nil
+        }
+    }
+}
+
+public enum WellbeingCheckInSnapshotError: LocalizedError, Sendable, Equatable {
+    case invalidResponse
+
+    public var errorDescription: String? {
+        "The completed wellbeing check-in could not be summarized."
+    }
+}

--- a/S2Y/CheckIn/WellbeingCheckInHistoryView.swift
+++ b/S2Y/CheckIn/WellbeingCheckInHistoryView.swift
@@ -1,0 +1,109 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct WellbeingCheckInHistoryView: View {
+    @StateObject private var store = WellbeingCheckInStore.shared
+    @State private var showingClearConfirmation = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            if store.snapshots.isEmpty {
+                ContentUnavailableView(
+                    "No check-ins yet",
+                    systemImage: "checkmark.circle",
+                    description: Text("Complete Daily Health Check-in from Schedule to build a private local history.")
+                )
+            } else {
+                Section {
+                    ForEach(store.snapshots) { snapshot in
+                        snapshotRow(snapshot)
+                    }
+                } header: {
+                    Text("On this iPhone")
+                } footer: {
+                    Text("These are minimized wellbeing summaries, not diagnoses or medical records.")
+                }
+
+                Section {
+                    Button("Clear local check-in history", role: .destructive) {
+                        showingClearConfirmation = true
+                    }
+                } footer: {
+                    Text("This does not alter Apple Health, provider records, or previously uploaded data.")
+                }
+            }
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("Daily Check-ins")
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            "Clear local check-in history?",
+            isPresented: $showingClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear from this iPhone", role: .destructive) {
+                clearHistory()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+
+    private func snapshotRow(_ snapshot: WellbeingCheckInSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(snapshot.recordedAt, format: .dateTime.weekday(.wide).month().day().year())
+                .font(.headline)
+
+            if let overallWellbeing = snapshot.overallWellbeing {
+                LabeledContent("Overall", value: displayValue(overallWellbeing))
+            }
+            if let energyLevel = snapshot.energyLevel {
+                LabeledContent("Energy", value: displayValue(energyLevel))
+            }
+            if let sleepQuality = snapshot.sleepQuality {
+                LabeledContent("Sleep", value: displayValue(sleepQuality))
+            }
+            if let stressLevel = snapshot.stressLevel {
+                LabeledContent("Stress", value: displayValue(stressLevel))
+            }
+            if let mood = snapshot.mood {
+                LabeledContent("Mood", value: displayValue(mood))
+            }
+            if !snapshot.reportedSymptoms.isEmpty {
+                LabeledContent(
+                    "Noted symptoms",
+                    value: snapshot.reportedSymptoms.map(displayValue).joined(separator: ", ")
+                )
+            }
+        }
+        .font(.subheadline)
+        .padding(.vertical, 4)
+    }
+
+    private func displayValue(_ value: String) -> String {
+        value.replacingOccurrences(of: "-", with: " ").capitalized
+    }
+
+    private func clearHistory() {
+        do {
+            try store.clear()
+        } catch {
+            errorMessage = "Local check-in history could not be cleared: \(error.localizedDescription)"
+        }
+    }
+}

--- a/S2Y/CheckIn/WellbeingCheckInStore.swift
+++ b/S2Y/CheckIn/WellbeingCheckInStore.swift
@@ -19,7 +19,6 @@ final class WellbeingCheckInStore: ObservableObject {
     private let fileURL: URL
     private let maximumSnapshotCount: Int
     private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
 
     init(
         fileManager: FileManager = .default,
@@ -33,7 +32,7 @@ final class WellbeingCheckInStore: ObservableObject {
             .appendingPathComponent("WellbeingCheckIns", isDirectory: true)
             .appendingPathComponent("snapshots.json")
         self.snapshots = (try? Data(contentsOf: self.fileURL))
-            .flatMap { try? decoder.decode([WellbeingCheckInSnapshot].self, from: $0) }
+            .flatMap { try? JSONDecoder().decode([WellbeingCheckInSnapshot].self, from: $0) }
             ?? []
     }
 

--- a/S2Y/CheckIn/WellbeingCheckInStore.swift
+++ b/S2Y/CheckIn/WellbeingCheckInStore.swift
@@ -1,0 +1,68 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class WellbeingCheckInStore: ObservableObject {
+    static let shared = WellbeingCheckInStore()
+
+    @Published private(set) var snapshots: [WellbeingCheckInSnapshot]
+
+    private let fileManager: FileManager
+    private let fileURL: URL
+    private let maximumSnapshotCount: Int
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(
+        fileManager: FileManager = .default,
+        fileURL: URL? = nil,
+        maximumSnapshotCount: Int = 90
+    ) {
+        self.fileManager = fileManager
+        self.maximumSnapshotCount = max(1, maximumSnapshotCount)
+        let supportDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        self.fileURL = fileURL ?? supportDirectory
+            .appendingPathComponent("WellbeingCheckIns", isDirectory: true)
+            .appendingPathComponent("snapshots.json")
+        self.snapshots = (try? Data(contentsOf: self.fileURL))
+            .flatMap { try? decoder.decode([WellbeingCheckInSnapshot].self, from: $0) }
+            ?? []
+    }
+
+    func save(_ snapshot: WellbeingCheckInSnapshot) throws {
+        var updated = snapshots.filter { $0.id != snapshot.id }
+        updated.append(snapshot)
+        updated.sort { $0.recordedAt > $1.recordedAt }
+        updated = Array(updated.prefix(maximumSnapshotCount))
+        try persist(updated)
+        snapshots = updated
+    }
+
+    func clear() throws {
+        if fileManager.fileExists(atPath: fileURL.path) {
+            try fileManager.removeItem(at: fileURL)
+        }
+        snapshots = []
+    }
+
+    private func persist(_ snapshots: [WellbeingCheckInSnapshot]) throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var mutableDirectory = directory
+        try? mutableDirectory.setResourceValues(resourceValues)
+        try encoder.encode(snapshots).write(
+            to: fileURL,
+            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+        )
+    }
+}

--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -81,6 +81,12 @@ struct HealthAssistantSettingsView: View {
 
             Section {
                 NavigationLink {
+                    WellbeingCheckInHistoryView()
+                } label: {
+                    Label("Daily Check-in History", systemImage: "checkmark.circle")
+                }
+
+                NavigationLink {
                     ClinicalRecordsSettingsView()
                 } label: {
                     Label("Clinical Record Summaries", systemImage: "cross.case")

--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -56,6 +56,16 @@ struct HealthAssistantSettingsView: View {
                     isOn: consentBinding(for: .clinicalRecordSummary)
                 )
 
+                Toggle(
+                    "Back up completed check-ins to S2Y account",
+                    isOn: consentBinding(for: .wellbeingCheckInCloudBackup)
+                )
+
+                Toggle(
+                    "Share recent check-in summaries with Omer",
+                    isOn: consentBinding(for: .wellbeingCheckInSummary)
+                )
+
                 NavigationLink {
                     HealthSafetyActivityView()
                 } label: {
@@ -67,6 +77,7 @@ struct HealthAssistantSettingsView: View {
                 Text(
                     "Each sharing choice is independent and can be withdrawn immediately. "
                         + "Clinical record summaries are never included under the general Health summary choice. "
+                        + "Check-in account backup and Omer analysis are separate choices. "
                         + "On-device analysis stays on this iPhone unless conversation sync is enabled."
                 )
             }

--- a/S2Y/HealthAssistant/HealthSharingConsent.swift
+++ b/S2Y/HealthAssistant/HealthSharingConsent.swift
@@ -18,6 +18,10 @@ public enum HealthSharingScope: String, Codable, Sendable, CaseIterable, Hashabl
     case onDeviceConversationSync
     /// A bounded set of selected clinical record summary fields.
     case clinicalRecordSummary
+    /// A completed questionnaire response stored in the user's S2Y account.
+    case wellbeingCheckInCloudBackup
+    /// A bounded set of recent wellbeing check-in summary fields.
+    case wellbeingCheckInSummary
 }
 
 public struct HealthSharingAuthorization: Codable, Sendable, Equatable {
@@ -50,6 +54,8 @@ private extension HealthSharingScope {
         case .relevantHealthSummary: "relevant Health summary"
         case .onDeviceConversationSync: "on-device conversation sync"
         case .clinicalRecordSummary: "selected clinical record summaries"
+        case .wellbeingCheckInCloudBackup: "wellbeing check-in account backup"
+        case .wellbeingCheckInSummary: "recent wellbeing check-in summaries"
         }
     }
 }

--- a/S2Y/HealthKit/ClinicalRecordsService.swift
+++ b/S2Y/HealthKit/ClinicalRecordsService.swift
@@ -175,7 +175,6 @@ final class ClinicalRecordIndexStore: ObservableObject {
     private let fileManager: FileManager
     private let fileURL: URL
     private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
 
     init(fileManager: FileManager = .default, fileURL: URL? = nil) {
         self.fileManager = fileManager
@@ -184,7 +183,7 @@ final class ClinicalRecordIndexStore: ObservableObject {
             .appendingPathComponent("ClinicalRecords", isDirectory: true)
             .appendingPathComponent("summary-index.json")
         self.index = (try? Data(contentsOf: self.fileURL))
-            .flatMap { try? decoder.decode(ClinicalRecordIndex.self, from: $0) }
+            .flatMap { try? JSONDecoder().decode(ClinicalRecordIndex.self, from: $0) }
     }
 
     func replace(with index: ClinicalRecordIndex) throws {

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -59,6 +59,15 @@ actor OmerChatService {
                 uniquingKeysWith: { _, clinical in clinical }
             )
         }
+        if HealthSharingConsentPolicy.permits(.wellbeingCheckInSummary, authorization: authorization),
+           let checkInSummary = await WellbeingCheckInContextBuilder.build(
+               from: WellbeingCheckInStore.shared.snapshots
+           ) {
+            healthContext = (healthContext ?? [:]).merging(
+                ["recentWellbeingCheckIns": checkInSummary],
+                uniquingKeysWith: { _, checkIn in checkIn }
+            )
+        }
         let body = OmerMobileChatRequest(
             requestId: requestID,
             conversationId: conversationID,

--- a/S2Y/S2YApplicationStandard.swift
+++ b/S2Y/S2YApplicationStandard.swift
@@ -74,8 +74,7 @@ actor S2YApplicationStandard: Standard,
         let questionnaireId = questionnaire.id?.value?.string
         
         if FeatureFlags.disableFirebase {
-            let jsonRepresentation = (try? String(data: JSONEncoder().encode(response), encoding: .utf8)) ?? ""
-            await logger.debug("Received questionnaire response \(jsonRepresentation) for questionnaire: \(questionnaireId ?? "unkown")")
+            await logger.debug("Skipped questionnaire account backup for: \(questionnaireId ?? "unknown")")
             return
         }
         

--- a/S2Y/Schedule/EventView.swift
+++ b/S2Y/Schedule/EventView.swift
@@ -15,7 +15,6 @@ import SwiftUI
 struct EventView: View {
     private let event: Event
     
-    @Environment(S2YApplicationStandard.self) private var standard
     @Environment(\.dismiss) private var dismiss
     
     @State private var viewState: ViewState = .idle
@@ -30,8 +29,14 @@ struct EventView: View {
                 }
                 
                 do {
+                    let data = try JSONEncoder().encode(response)
+                    let questionnaireID = questionnaire.id?.value?.string ?? "unknown-questionnaire"
+                    let snapshot = try WellbeingCheckInSnapshotBuilder.build(
+                        responseData: data,
+                        questionnaireIdentifier: questionnaireID
+                    )
+                    try WellbeingCheckInStore.shared.save(snapshot)
                     _ = try event.complete()
-                    await standard.add(response: response, for: questionnaire)
                     dismiss()
                 } catch {
                     viewState = .error(AnyLocalizedError(error: error))

--- a/S2Y/Schedule/EventView.swift
+++ b/S2Y/Schedule/EventView.swift
@@ -15,7 +15,9 @@ import SwiftUI
 struct EventView: View {
     private let event: Event
     
+    @Environment(S2YApplicationStandard.self) private var standard
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var sharingConsentStore = HealthSharingConsentStore.shared
     
     @State private var viewState: ViewState = .idle
     
@@ -37,6 +39,12 @@ struct EventView: View {
                     )
                     try WellbeingCheckInStore.shared.save(snapshot)
                     _ = try event.complete()
+                    if HealthSharingConsentPolicy.permits(
+                        .wellbeingCheckInCloudBackup,
+                        authorization: sharingConsentStore.authorization
+                    ) {
+                        await standard.add(response: response, for: questionnaire)
+                    }
                     dismiss()
                 } catch {
                     viewState = .error(AnyLocalizedError(error: error))

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1328,6 +1328,36 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(snapshot.reportedSymptoms.count, 8)
     }
 
+    @MainActor
+    func testWellbeingCheckInStorePersistsBoundsAndClearsSnapshots() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = directory.appendingPathComponent("snapshots.json")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let now = Date()
+        let store = WellbeingCheckInStore(fileURL: fileURL, maximumSnapshotCount: 2)
+
+        for offset in 0..<3 {
+            try store.save(WellbeingCheckInSnapshot(
+                recordedAt: now.addingTimeInterval(TimeInterval(offset)),
+                questionnaireIdentifier: "DailyHealth",
+                overallWellbeing: "good"
+            ))
+        }
+
+        XCTAssertEqual(store.snapshots.count, 2)
+        XCTAssertEqual(store.snapshots.first?.recordedAt, now.addingTimeInterval(2))
+        XCTAssertEqual(
+            WellbeingCheckInStore(fileURL: fileURL, maximumSnapshotCount: 2).snapshots,
+            store.snapshots
+        )
+
+        try store.clear()
+
+        XCTAssertTrue(store.snapshots.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
     func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {
         var ledger = HealthSharingConsentLedger()
         ledger.apply(.granted, scopes: [.omerChatText, .onDeviceConversationSync])

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1287,6 +1287,47 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertLessThanOrEqual(context.count, 500)
     }
 
+    func testWellbeingCheckInBuildsMinimizedSnapshotWithoutFreeTextNotes() throws {
+        let response = Data(#"""
+        {
+          "item": [
+            {"linkId":"overall-wellness","answer":[{"valueCoding":{"code":"good"}}]},
+            {"linkId":"sleep-hours","answer":[{"valueDecimal":7.5}]},
+            {"linkId":"symptoms","answer":[
+              {"valueCoding":{"code":"headache"}},
+              {"valueCoding":{"code":"fatigue"}}
+            ]},
+            {"linkId":"notes","answer":[{"valueString":"Private free text details"}]},
+            {"linkId":"goals-today","answer":[{"valueCoding":{"code":"better-sleep"}}]}
+          ]
+        }
+        """#.utf8)
+
+        let snapshot = try WellbeingCheckInSnapshotBuilder.build(
+            responseData: response,
+            questionnaireIdentifier: "DailyHealth"
+        )
+
+        XCTAssertEqual(snapshot.overallWellbeing, "good")
+        XCTAssertEqual(snapshot.sleepHours, 7.5)
+        XCTAssertEqual(snapshot.reportedSymptoms, ["headache", "fatigue"])
+        XCTAssertEqual(snapshot.goalFocus, "better-sleep")
+        let encoded = String(decoding: try encoder.encode(snapshot), as: UTF8.self)
+        XCTAssertFalse(encoded.contains("Private free text details"))
+        XCTAssertFalse(encoded.contains("notes"))
+    }
+
+    func testWellbeingCheckInBoundsInvalidValuesAndSymptomCount() {
+        let snapshot = WellbeingCheckInSnapshot(
+            questionnaireIdentifier: "DailyHealth",
+            sleepHours: 25,
+            reportedSymptoms: (0..<12).map { "symptom-\($0)" }
+        )
+
+        XCTAssertNil(snapshot.sleepHours)
+        XCTAssertEqual(snapshot.reportedSymptoms.count, 8)
+    }
+
     func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {
         var ledger = HealthSharingConsentLedger()
         ledger.apply(.granted, scopes: [.omerChatText, .onDeviceConversationSync])

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1196,6 +1196,8 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertFalse(HealthSharingConsentPolicy.permits(.relevantHealthSummary, authorization: authorization))
         XCTAssertFalse(HealthSharingConsentPolicy.permits(.onDeviceConversationSync, authorization: authorization))
         XCTAssertFalse(HealthSharingConsentPolicy.permits(.clinicalRecordSummary, authorization: authorization))
+        XCTAssertFalse(HealthSharingConsentPolicy.permits(.wellbeingCheckInCloudBackup, authorization: authorization))
+        XCTAssertFalse(HealthSharingConsentPolicy.permits(.wellbeingCheckInSummary, authorization: authorization))
         XCTAssertEqual(
             HealthSharingConsentPolicy.decision(
                 requestedScopes: [.omerChatText, .relevantHealthSummary],
@@ -1356,6 +1358,43 @@ final class OmerMobileChatModelsTests: XCTestCase {
 
         XCTAssertTrue(store.snapshots.isEmpty)
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    func testWellbeingCheckInOutboundPurposesAreIndependent() {
+        let authorization = HealthSharingAuthorization(grantedScopes: [.wellbeingCheckInCloudBackup])
+
+        XCTAssertTrue(
+            HealthSharingConsentPolicy.permits(.wellbeingCheckInCloudBackup, authorization: authorization)
+        )
+        XCTAssertFalse(HealthSharingConsentPolicy.permits(.wellbeingCheckInSummary, authorization: authorization))
+        XCTAssertFalse(HealthSharingConsentPolicy.permits(.omerChatText, authorization: authorization))
+    }
+
+    func testWellbeingCheckInContextIsBoundedAndExcludesLocalIdentifiers() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let snapshots = (0..<4).map { offset in
+            WellbeingCheckInSnapshot(
+                id: UUID(),
+                recordedAt: now.addingTimeInterval(TimeInterval(-offset * 24 * 60 * 60)),
+                questionnaireIdentifier: "PrivateQuestionnaireIdentifier",
+                overallWellbeing: "good",
+                sleepQuality: "fair",
+                reportedSymptoms: ["fatigue"]
+            )
+        }
+
+        let context = try XCTUnwrap(WellbeingCheckInContextBuilder.build(
+            from: snapshots,
+            maximumSnapshotCount: 2,
+            maximumCharacterCount: 500
+        ))
+
+        XCTAssertEqual(context.components(separatedBy: "\n").count, 2)
+        XCTAssertTrue(context.contains("overall=good"))
+        XCTAssertTrue(context.contains("symptoms=fatigue"))
+        XCTAssertFalse(context.contains("PrivateQuestionnaireIdentifier"))
+        XCTAssertFalse(context.contains(snapshots[0].id.uuidString))
+        XCTAssertLessThanOrEqual(context.count, 500)
     }
 
     func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {


### PR DESCRIPTION
## Theme

Turn the existing scheduled daily FHIR questionnaire into a local-first wellbeing check-in flow with explicit, purpose-specific outbound consent.

## Stories

- HLT-037: derive a bounded non-diagnostic snapshot and exclude free-text notes
- HLT-038: persist completed snapshots locally with file protection and bounded history
- HLT-039: expose private history and local deletion in Health Assistant settings
- HLT-040: separate Firebase questionnaire backup from minimized Omer check-in context

## Validation

- iPhone 17 simulator arm64 app build passed
- Full unit test suite passed (UI tests excluded)
- `git diff --check` passed

## Privacy boundary

Both outbound purposes default to off. Full questionnaire backup to the S2Y account and minimized Omer summary sharing require separate choices. Disabled Firebase logging no longer prints the raw questionnaire response.