### PR TITLE
EPIC-H11: local health data controls

### DIFF
--- a/S2Y/Bluetooth/WellnessSessionAudit.swift
+++ b/S2Y/Bluetooth/WellnessSessionAudit.swift
@@ -95,6 +95,11 @@ final class WellnessSessionAuditStore: ObservableObject {
         persist()
     }
 
+    func clear() {
+        log = WellnessSessionAuditLog()
+        defaults.removeObject(forKey: storageKey)
+    }
+
     private func persist() {
         guard let data = try? encoder.encode(log) else { return }
         defaults.set(data, forKey: storageKey)

--- a/S2Y/DataControls/LocalHealthDataControlsView.swift
+++ b/S2Y/DataControls/LocalHealthDataControlsView.swift
@@ -1,0 +1,217 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct LocalHealthDataControlsView: View {
+    @State private var inventory: LocalHealthDataInventorySnapshot?
+    @State private var categoryPendingDeletion: LocalHealthDataCategory?
+    @State private var showingDeleteAllConfirmation = false
+    @State private var exportURL: URL?
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            inventorySection
+            exportSection
+            deletionSection
+            cloudBoundarySection
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("Data Controls")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await refreshInventory()
+        }
+        .onDisappear {
+            removeTemporaryExport()
+        }
+        .confirmationDialog(
+            "Clear \(categoryPendingDeletion?.title ?? "this category")?",
+            isPresented: Binding(
+                get: { categoryPendingDeletion != nil },
+                set: { if !$0 { categoryPendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Clear from this iPhone", role: .destructive) {
+                guard let category = categoryPendingDeletion else { return }
+                categoryPendingDeletion = nil
+                Task { await clear(category) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Cloud copies are not affected.")
+        }
+        .confirmationDialog(
+            "Clear all local Health Assistant data?",
+            isPresented: $showingDeleteAllConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear all from this iPhone", role: .destructive) {
+                Task { await clearAll() }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This cannot be undone. Apple Health and cloud copies are not affected.")
+        }
+    }
+
+    @ViewBuilder
+    private var inventorySection: some View {
+        Section {
+            if let inventory {
+                ForEach(inventory.items) { item in
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(item.category.title)
+                            Text(item.storageDescription)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(item.itemCount.formatted())
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+            } else {
+                ProgressView("Checking local data…")
+            }
+        } header: {
+            Text("On this iPhone")
+        } footer: {
+            Text("Counts describe S2Y's local copies. They do not count data in Apple Health, Firebase, or Omer.")
+        }
+    }
+
+    private var exportSection: some View {
+        Section {
+            Button {
+                Task { await prepareExport() }
+            } label: {
+                Label("Prepare Local Data Export", systemImage: "square.and.arrow.up")
+            }
+            .disabled(isWorking)
+
+            if let exportURL {
+                ShareLink(item: exportURL) {
+                    Label("Share Prepared Export", systemImage: "doc")
+                }
+            }
+        } header: {
+            Text("Export")
+        } footer: {
+            Text(
+                "The JSON export can include chat text and sensitive health-related summaries. "
+                    + "Store and share it securely."
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var deletionSection: some View {
+        Section {
+            if let inventory {
+                ForEach(inventory.items.filter { $0.itemCount > 0 }) { item in
+                    Button("Clear \(item.category.title)", role: .destructive) {
+                        categoryPendingDeletion = item.category
+                    }
+                    .disabled(isWorking)
+                }
+            }
+
+            Button("Clear All Local Health Assistant Data", role: .destructive) {
+                showingDeleteAllConfirmation = true
+            }
+            .disabled(isWorking || inventory?.items.allSatisfy { $0.itemCount == 0 } == true)
+        } header: {
+            Text("Delete local data")
+        } footer: {
+            Text("Clearing sharing receipts also returns every outbound sharing choice to off.")
+        }
+    }
+
+    private var cloudBoundarySection: some View {
+        Section("Cloud data") {
+            Label("Firebase account copies", systemImage: "person.crop.circle.badge.checkmark")
+            Label("Omer conversations", systemImage: "bubble.left.and.bubble.right")
+
+            Text(
+                "Local deletion never sends a remote deletion request. "
+                    + "Cloud data must be deleted through the corresponding account service."
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @MainActor
+    private func refreshInventory() async {
+        inventory = await LocalHealthDataInventory.current()
+    }
+
+    @MainActor
+    private func prepareExport() async {
+        isWorking = true
+        errorMessage = nil
+        removeTemporaryExport()
+        defer { isWorking = false }
+
+        do {
+            let package = await LocalHealthDataExportService.makePackage()
+            let data = try LocalHealthDataExportService.encodedData(for: package)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("S2Y-Local-Health-Data.json")
+            try data.write(to: url, options: [.atomic, .completeFileProtection])
+            exportURL = url
+        } catch {
+            errorMessage = "The local data export could not be prepared: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func clear(_ category: LocalHealthDataCategory) async {
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+        do {
+            try await LocalHealthDataDeletionService.clear(category)
+            await refreshInventory()
+        } catch {
+            errorMessage = "\(category.title) could not be cleared: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func clearAll() async {
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+        do {
+            try await LocalHealthDataDeletionService.clearAll()
+            removeTemporaryExport()
+            await refreshInventory()
+        } catch {
+            errorMessage = "Local Health Assistant data could not be cleared: \(error.localizedDescription)"
+        }
+    }
+
+    private func removeTemporaryExport() {
+        guard let exportURL else { return }
+        try? FileManager.default.removeItem(at: exportURL)
+        self.exportURL = nil
+    }
+}

--- a/S2Y/DataControls/LocalHealthDataDeletion.swift
+++ b/S2Y/DataControls/LocalHealthDataDeletion.swift
@@ -1,0 +1,41 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+@MainActor
+enum LocalHealthDataDeletionService {
+    static func clear(_ category: LocalHealthDataCategory) async throws {
+        switch category {
+        case .chatCopies:
+            await OmerChatService.shared.clearLocalChatCache()
+        case .clinicalSummaries:
+            try ClinicalRecordIndexStore.shared.clear()
+        case .wellbeingCheckIns:
+            try WellbeingCheckInStore.shared.clear()
+        case .wellbeingPlans:
+            WellnessPlanStore.shared.clear()
+        case .wellbeingActionRecords:
+            WellnessActionRecordStore.shared.clear()
+        case .wellnessSessionActivity:
+            WellnessSessionAuditStore.shared.clear()
+        case .safetyActivity:
+            HealthSafetyEventStore.shared.clear()
+        case .sharingConsentReceipts:
+            HealthSharingConsentStore.shared.clear()
+        case .temporaryHealthCache:
+            HealthKitCache.shared.clearAll()
+        }
+    }
+
+    static func clearAll() async throws {
+        for category in LocalHealthDataCategory.allCases {
+            try await clear(category)
+        }
+    }
+}

--- a/S2Y/DataControls/LocalHealthDataExport.swift
+++ b/S2Y/DataControls/LocalHealthDataExport.swift
@@ -1,0 +1,75 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+struct LocalHealthDataExportPackage: Codable, Sendable {
+    let formatVersion: Int
+    let generatedAt: Date
+    let inventory: LocalHealthDataInventorySnapshot
+    let localChatCache: OmerChatCacheSnapshot
+    let clinicalRecordSummaries: [ClinicalRecordSummary]
+    let wellbeingCheckIns: [WellbeingCheckInSnapshot]
+    let wellbeingPlans: [WellnessPlan]
+    let wellbeingActionRecords: [WellnessActionRecord]
+    let wellnessSessionActivity: [WellnessSessionAuditRecord]
+    let safetyActivity: [HealthSafetyEvent]
+    let sharingConsentReceipts: [HealthSharingConsentReceipt]
+
+    init(
+        generatedAt: Date,
+        inventory: LocalHealthDataInventorySnapshot,
+        localChatCache: OmerChatCacheSnapshot,
+        clinicalRecordSummaries: [ClinicalRecordSummary] = [],
+        wellbeingCheckIns: [WellbeingCheckInSnapshot] = [],
+        wellbeingPlans: [WellnessPlan] = [],
+        wellbeingActionRecords: [WellnessActionRecord] = [],
+        wellnessSessionActivity: [WellnessSessionAuditRecord] = [],
+        safetyActivity: [HealthSafetyEvent] = [],
+        sharingConsentReceipts: [HealthSharingConsentReceipt] = []
+    ) {
+        self.formatVersion = 1
+        self.generatedAt = generatedAt
+        self.inventory = inventory
+        self.localChatCache = localChatCache
+        self.clinicalRecordSummaries = clinicalRecordSummaries
+        self.wellbeingCheckIns = wellbeingCheckIns
+        self.wellbeingPlans = wellbeingPlans
+        self.wellbeingActionRecords = wellbeingActionRecords
+        self.wellnessSessionActivity = wellnessSessionActivity
+        self.safetyActivity = safetyActivity
+        self.sharingConsentReceipts = sharingConsentReceipts
+    }
+}
+
+@MainActor
+enum LocalHealthDataExportService {
+    static func makePackage(at date: Date = .now) async -> LocalHealthDataExportPackage {
+        let inventory = await LocalHealthDataInventory.current(at: date)
+        let chatCache = await OmerChatService.shared.localExportSnapshot()
+        return LocalHealthDataExportPackage(
+            generatedAt: date,
+            inventory: inventory,
+            localChatCache: chatCache,
+            clinicalRecordSummaries: ClinicalRecordIndexStore.shared.index?.records ?? [],
+            wellbeingCheckIns: WellbeingCheckInStore.shared.snapshots,
+            wellbeingPlans: WellnessPlanStore.shared.plans,
+            wellbeingActionRecords: WellnessActionRecordStore.shared.records,
+            wellnessSessionActivity: WellnessSessionAuditStore.shared.log.records,
+            safetyActivity: HealthSafetyEventStore.shared.log.events,
+            sharingConsentReceipts: HealthSharingConsentStore.shared.ledger.receipts
+        )
+    }
+
+    static func encodedData(for package: LocalHealthDataExportPackage) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(package)
+    }
+}

--- a/S2Y/DataControls/LocalHealthDataExport.swift
+++ b/S2Y/DataControls/LocalHealthDataExport.swift
@@ -66,7 +66,7 @@ enum LocalHealthDataExportService {
         )
     }
 
-    static func encodedData(for package: LocalHealthDataExportPackage) throws -> Data {
+    nonisolated static func encodedData(for package: LocalHealthDataExportPackage) throws -> Data {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/S2Y/DataControls/LocalHealthDataInventory.swift
+++ b/S2Y/DataControls/LocalHealthDataInventory.swift
@@ -1,0 +1,90 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+public enum LocalHealthDataCategory: String, CaseIterable, Codable, Sendable, Identifiable {
+    case chatCopies
+    case clinicalSummaries
+    case wellbeingCheckIns
+    case wellbeingPlans
+    case wellbeingActionRecords
+    case wellnessSessionActivity
+    case safetyActivity
+    case sharingConsentReceipts
+    case temporaryHealthCache
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .chatCopies: "Local chat copies"
+        case .clinicalSummaries: "Clinical record summaries"
+        case .wellbeingCheckIns: "Daily wellbeing check-ins"
+        case .wellbeingPlans: "Wellbeing plans"
+        case .wellbeingActionRecords: "Plan action history"
+        case .wellnessSessionActivity: "Connected wellness session activity"
+        case .safetyActivity: "Safety routing activity"
+        case .sharingConsentReceipts: "Sharing consent receipts"
+        case .temporaryHealthCache: "Temporary Health data cache"
+        }
+    }
+
+    public var storageDescription: String {
+        switch self {
+        case .temporaryHealthCache:
+            "Memory only; expires automatically"
+        default:
+            "Stored on this iPhone"
+        }
+    }
+}
+
+public struct LocalHealthDataInventoryItem: Codable, Identifiable, Sendable, Equatable {
+    public let category: LocalHealthDataCategory
+    public let itemCount: Int
+    public let storageDescription: String
+
+    public var id: LocalHealthDataCategory { category }
+
+    public init(category: LocalHealthDataCategory, itemCount: Int) {
+        self.category = category
+        self.itemCount = max(0, itemCount)
+        self.storageDescription = category.storageDescription
+    }
+}
+
+public struct LocalHealthDataInventorySnapshot: Codable, Sendable, Equatable {
+    public let generatedAt: Date
+    public let items: [LocalHealthDataInventoryItem]
+
+    public init(generatedAt: Date = .now, counts: [LocalHealthDataCategory: Int]) {
+        self.generatedAt = generatedAt
+        self.items = LocalHealthDataCategory.allCases.map { category in
+            LocalHealthDataInventoryItem(category: category, itemCount: counts[category] ?? 0)
+        }
+    }
+}
+
+@MainActor
+enum LocalHealthDataInventory {
+    static func current(at date: Date = .now) async -> LocalHealthDataInventorySnapshot {
+        let chatCount = await OmerChatService.shared.cachedChats(limit: 50).count
+        return LocalHealthDataInventorySnapshot(generatedAt: date, counts: [
+            .chatCopies: chatCount,
+            .clinicalSummaries: ClinicalRecordIndexStore.shared.index?.records.count ?? 0,
+            .wellbeingCheckIns: WellbeingCheckInStore.shared.snapshots.count,
+            .wellbeingPlans: WellnessPlanStore.shared.plans.count,
+            .wellbeingActionRecords: WellnessActionRecordStore.shared.records.count,
+            .wellnessSessionActivity: WellnessSessionAuditStore.shared.log.records.count,
+            .safetyActivity: HealthSafetyEventStore.shared.log.events.count,
+            .sharingConsentReceipts: HealthSharingConsentStore.shared.ledger.receipts.count,
+            .temporaryHealthCache: HealthKitCache.shared.entryCount
+        ])
+    }
+}

--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -12,8 +12,6 @@ struct HealthAssistantSettingsView: View {
     let showsDismissButton: Bool
 
     @Environment(\.dismiss) private var dismiss
-    @State private var showingCacheClearedAlert = false
-    @State private var showingChatCacheClearedAlert = false
     @StateObject private var sharingConsentStore = HealthSharingConsentStore.shared
 
     init(showsDismissButton: Bool = false) {
@@ -92,6 +90,12 @@ struct HealthAssistantSettingsView: View {
 
             Section {
                 NavigationLink {
+                    LocalHealthDataControlsView()
+                } label: {
+                    Label("Data Controls", systemImage: "externaldrive.badge.checkmark")
+                }
+
+                NavigationLink {
                     WellbeingCheckInHistoryView()
                 } label: {
                     Label("Daily Check-in History", systemImage: "checkmark.circle")
@@ -102,22 +106,10 @@ struct HealthAssistantSettingsView: View {
                 } label: {
                     Label("Clinical Record Summaries", systemImage: "cross.case")
                 }
-
-                Button("Clear locally saved chat history", role: .destructive) {
-                    Task {
-                        await OmerChatService.shared.clearLocalChatCache()
-                        showingChatCacheClearedAlert = true
-                    }
-                }
-
-                Button("Clear Health data cache", role: .destructive) {
-                    HealthKitCache.shared.clearAll()
-                    showingCacheClearedAlert = true
-                }
             } header: {
                 Text("Data")
             } footer: {
-                Text("Manage clinical summaries separately. Cache actions never delete data from Apple Health.")
+                Text("Review, export, or delete S2Y's local copies. Apple Health and cloud data remain separate.")
             }
         }
         .navigationTitle("Health Assistant")
@@ -130,16 +122,6 @@ struct HealthAssistantSettingsView: View {
                     }
                 }
             }
-        }
-        .alert("Cache cleared", isPresented: $showingCacheClearedAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text("Cached Health summaries were removed from this iPhone.")
-        }
-        .alert("Local chat history cleared", isPresented: $showingChatCacheClearedAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text("Locally saved chat copies were removed. This does not delete conversations already synced to your S2Y account.")
         }
     }
 

--- a/S2Y/HealthAssistant/HealthSharingConsent.swift
+++ b/S2Y/HealthAssistant/HealthSharingConsent.swift
@@ -180,6 +180,11 @@ final class HealthSharingConsentStore: ObservableObject {
         persist()
     }
 
+    func clear() {
+        ledger = HealthSharingConsentLedger()
+        defaults.removeObject(forKey: storageKey)
+    }
+
     private func persist() {
         guard let data = try? encoder.encode(ledger) else { return }
         defaults.set(data, forKey: storageKey)

--- a/S2Y/HealthKit/HealthKitCache.swift
+++ b/S2Y/HealthKit/HealthKitCache.swift
@@ -25,6 +25,11 @@ public final class HealthKitCache {
     
     private var cache: [String: CachedResult] = [:]
     private let defaultExpiryInterval: TimeInterval = 300 // 5 minutes
+
+    public var entryCount: Int {
+        cleanupExpired()
+        return cache.count
+    }
     
     private init() {}
     

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -198,6 +198,10 @@ actor OmerChatService {
         chatCache.details.first { $0.chat.id == id }
     }
 
+    func localExportSnapshot() -> OmerChatCacheSnapshot {
+        chatCache
+    }
+
     func selectChat(id: UUID) async throws {
         let serviceURL = try configuredServiceURL()
         await sessionStore.saveLastChatId(id.uuidString, sessionKey: sessionKey(for: serviceURL))

--- a/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
@@ -96,6 +96,11 @@ final class WellnessActionRecordStore: ObservableObject {
         persist()
     }
 
+    func clear() {
+        records = []
+        defaults.removeObject(forKey: storageKey)
+    }
+
     private func persist() {
         guard let data = try? JSONEncoder().encode(records) else { return }
         defaults.set(data, forKey: storageKey)

--- a/S2Y/WellnessPlan/WellnessPlanModels.swift
+++ b/S2Y/WellnessPlan/WellnessPlanModels.swift
@@ -200,6 +200,11 @@ final class WellnessPlanStore: ObservableObject {
         persist()
     }
 
+    func clear() {
+        plans = []
+        defaults.removeObject(forKey: storageKey)
+    }
+
     private func load() {
         guard let data = defaults.data(forKey: storageKey),
               let decoded = try? decoder.decode([WellnessPlan].self, from: data) else {

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1428,6 +1428,22 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertFalse(json.contains("resourceType"))
     }
 
+    @MainActor
+    func testClearingSharingReceiptsAlsoReturnsEveryScopeToDefaultDeny() {
+        let suiteName = "HealthSharingConsentStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = HealthSharingConsentStore(defaults: defaults)
+        store.set(.omerChatText, granted: true)
+        store.set(.wellbeingCheckInCloudBackup, granted: true)
+
+        store.clear()
+
+        XCTAssertTrue(store.ledger.receipts.isEmpty)
+        XCTAssertTrue(store.authorization.grantedScopes.isEmpty)
+        XCTAssertNil(defaults.data(forKey: "healthSharingConsent.v1"))
+    }
+
     func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {
         var ledger = HealthSharingConsentLedger()
         ledger.apply(.granted, scopes: [.omerChatText, .onDeviceConversationSync])

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1397,6 +1397,19 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertLessThanOrEqual(context.count, 500)
     }
 
+    func testLocalHealthDataInventoryIncludesEveryCategoryAndBoundsCounts() {
+        let snapshot = LocalHealthDataInventorySnapshot(counts: [
+            .wellbeingCheckIns: 3,
+            .safetyActivity: -1
+        ])
+
+        XCTAssertEqual(snapshot.items.count, LocalHealthDataCategory.allCases.count)
+        XCTAssertEqual(Set(snapshot.items.map(\.category)), Set(LocalHealthDataCategory.allCases))
+        XCTAssertEqual(snapshot.items.first { $0.category == .wellbeingCheckIns }?.itemCount, 3)
+        XCTAssertEqual(snapshot.items.first { $0.category == .safetyActivity }?.itemCount, 0)
+        XCTAssertTrue(snapshot.items.allSatisfy { !$0.storageDescription.isEmpty })
+    }
+
     func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {
         var ledger = HealthSharingConsentLedger()
         ledger.apply(.granted, scopes: [.omerChatText, .onDeviceConversationSync])

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1410,6 +1410,24 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(snapshot.items.allSatisfy { !$0.storageDescription.isEmpty })
     }
 
+    func testLocalHealthDataExportIsVersionedAndExcludesRawFHIRFields() throws {
+        let generatedAt = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
+        let package = LocalHealthDataExportPackage(
+            generatedAt: generatedAt,
+            inventory: LocalHealthDataInventorySnapshot(generatedAt: generatedAt, counts: [:]),
+            localChatCache: OmerChatCacheSnapshot(chats: [], details: [])
+        )
+
+        let data = try LocalHealthDataExportService.encodedData(for: package)
+        let json = String(decoding: data, as: UTF8.self)
+
+        XCTAssertTrue(json.contains(#""formatVersion" : 1"#))
+        XCTAssertTrue(json.contains(#""generatedAt""#))
+        XCTAssertTrue(json.contains(#""localChatCache""#))
+        XCTAssertFalse(json.contains("fhirResourceIdentifier"))
+        XCTAssertFalse(json.contains("resourceType"))
+    }
+
     func testRevokingOnDeviceSyncDoesNotRevokeOmerQuestionConsent() {
         var ledger = HealthSharingConsentLedger()
         ledger.apply(.granted, scopes: [.omerChatText, .onDeviceConversationSync])


### PR DESCRIPTION
## Theme

Give users a single, explicit view of Health Assistant data stored on the iPhone, with portable export and scoped deletion.

## Stories

- HLT-041: inventory every local Health Assistant data category and count
- HLT-042: generate a versioned user-triggered JSON export
- HLT-043: clear data by category or clear all, including consent reset
- HLT-044: expose controls in settings and distinguish local, Apple Health, Firebase, and Omer boundaries

## Validation

- iPhone 17 simulator arm64 app build passed
- Full unit test suite passed (UI tests excluded)
- `git diff --check` passed

## Safety and privacy

Exports are temporary protected files and the UI warns that they may contain sensitive chat and health summaries. Local deletion never claims to delete Apple Health or cloud data.