### PR TITLE
EPIC-H12: reliable on-device AI states

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -14,6 +14,10 @@ struct HealthAssistantSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var sharingConsentStore = HealthSharingConsentStore.shared
 
+    private var appleModelAvailability: AppleFoundationModelAvailability {
+        AppleFoundationModelService.shared.availability
+    }
+
     init(showsDismissButton: Bool = false) {
         self.showsDismissButton = showsDismissButton
     }
@@ -23,14 +27,17 @@ struct HealthAssistantSettingsView: View {
             Section {
                 LabeledContent(
                     "On-device AI",
-                    value: AppleFoundationModelService.shared.availability.isAvailable ? "Available" : "Unavailable"
+                    value: appleModelAvailability.statusTitle
                 )
 
                 LabeledContent("AI provider", value: "Choose in chat")
             } header: {
                 Text("AI")
             } footer: {
-                Text("Choose On-device or Omer Online above the chat input. S2Y never changes providers without your selection.")
+                Text(
+                    appleModelAvailability.recoveryGuidance
+                        + " S2Y never changes providers without your selection."
+                )
             }
 
             Section {

--- a/S2Y/HealthAssistant/HealthAssistantView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView.swift
@@ -521,21 +521,25 @@ struct HealthAssistantView: View {
                 return
             } catch {
                 logger.error("Apple on-device generation failed: \(error.localizedDescription)")
+                notice = AssistantNotice(
+                    message: "The on-device response stopped. Your question was not sent online. You can retry or manually choose Omer Online.",
+                    tone: .warning
+                )
                 updateAssistantMessage(
                     id: assistantPlaceholder.id,
-                    content: "On-device Apple AI could not finish this response: \(error.localizedDescription)"
+                    content: "On-device Apple AI could not finish this response. Your question stayed on this iPhone."
                 )
                 isProcessing = false
                 return
             }
         } else if selectedAIMode == .onDevice {
             notice = AssistantNotice(
-                message: appleModelService.availability.fallbackExplanation.replacingOccurrences(of: "Using Omer instead.", with: "Choose Omer Online to continue."),
+                message: appleModelService.availability.recoveryGuidance,
                 tone: .warning
             )
             updateAssistantMessage(
                 id: assistantPlaceholder.id,
-                content: "On-device Apple AI is not available. Choose Omer Online from the provider menu to send this request online."
+                content: "On-device Apple AI is not ready. Your question was not sent online. \(appleModelService.availability.recoveryGuidance)"
             )
             isProcessing = false
             return

--- a/S2Y/LLM/AppleFoundationModelService.swift
+++ b/S2Y/LLM/AppleFoundationModelService.swift
@@ -27,22 +27,34 @@ enum AppleFoundationModelAvailability: Equatable, Sendable {
         self == .available
     }
 
-    var fallbackExplanation: String {
+    var statusTitle: String {
+        switch self {
+        case .available: "Ready"
+        case .unavailable(.requiresNewerOS): "Requires a newer iOS version"
+        case .unavailable(.deviceNotEligible): "Not supported on this device"
+        case .unavailable(.appleIntelligenceNotEnabled): "Apple Intelligence is off"
+        case .unavailable(.modelNotReady): "Apple model is preparing"
+        case .unavailable(.simulatorUnsupported): "Unavailable in Simulator"
+        case .unavailable(.frameworkUnavailable): "Unavailable in this build"
+        }
+    }
+
+    var recoveryGuidance: String {
         switch self {
         case .available:
-            return ""
+            return "On-device requests stay on this iPhone."
         case .unavailable(.requiresNewerOS):
-            return "On-device AI requires iOS 26 or later. Using Omer instead."
+            return "Update iOS to use Apple's on-device model, or manually choose Omer Online."
         case .unavailable(.deviceNotEligible):
-            return "This device does not support Apple Intelligence. Using Omer instead."
+            return "This device cannot run Apple's on-device model. Manually choose Omer Online to continue."
         case .unavailable(.appleIntelligenceNotEnabled):
-            return "Apple Intelligence is turned off. Using Omer instead."
+            return "Turn on Apple Intelligence in iPhone Settings, then return here and try again."
         case .unavailable(.modelNotReady):
-            return "The on-device Apple model is not ready yet. Using Omer instead."
+            return "Keep the iPhone connected to power and Wi-Fi while Apple finishes preparing its model."
         case .unavailable(.simulatorUnsupported):
-            return "On-device Apple AI is not available in Simulator. Using Omer instead."
+            return "Use an eligible iPhone to test Apple on-device AI, or manually choose Omer Online."
         case .unavailable(.frameworkUnavailable):
-            return "On-device AI is unavailable in this build. Using Omer instead."
+            return "Install a build that includes Apple Foundation Models, or manually choose Omer Online."
         }
     }
 }
@@ -53,7 +65,7 @@ enum AppleFoundationModelError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .unavailable(let availability):
-            return availability.fallbackExplanation
+            return availability.recoveryGuidance
         }
     }
 }

--- a/S2Y/LLM/LocalLLMService.swift
+++ b/S2Y/LLM/LocalLLMService.swift
@@ -55,7 +55,7 @@ public enum LocalModelConfig: String, CaseIterable, Codable, Identifiable, Senda
 // ============================================================
 
 /// Errors that can occur in LocalLLMService
-public enum LocalLLMError: Error, LocalizedError, Sendable {
+public enum LocalLLMError: Error, LocalizedError, Sendable, Equatable {
     case insufficientMemory(required: Int, available: Int)
     case modelNotLoaded
     case modelDownloadFailed(String)
@@ -79,6 +79,13 @@ public enum LocalLLMError: Error, LocalizedError, Sendable {
             return "Model not supported"
         }
     }
+}
+
+public enum LocalLLMServiceState: Sendable, Equatable {
+    case idle
+    case loading(progress: Double)
+    case ready(model: LocalModelConfig)
+    case failed(LocalLLMError)
 }
 
 // ============================================================
@@ -179,6 +186,19 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
     
     /// Error message if any
     @Published public private(set) var lastError: LocalLLMError?
+
+    public var state: LocalLLMServiceState {
+        if let lastError {
+            return .failed(lastError)
+        }
+        if isModelLoaded, let currentModel {
+            return .ready(model: currentModel)
+        }
+        if loadingProgress > 0 {
+            return .loading(progress: loadingProgress)
+        }
+        return .idle
+    }
     
     // MARK: - Private Properties
     
@@ -211,6 +231,8 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
         _ config: LocalModelConfig,
         progressHandler: ((Double) -> Void)? = nil
     ) async throws {
+        lastError = nil
+
         // Check if already loaded
         if isModelLoaded, currentModel == config {
             return
@@ -266,10 +288,18 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
             lastError = nil
             
         } catch let error as LocalLLMError {
+            modelContainer = nil
+            isModelLoaded = false
+            currentModel = nil
+            loadingProgress = 0
             lastError = error
             throw error
         } catch {
             let error = LocalLLMError.modelLoadFailed(error.localizedDescription)
+            modelContainer = nil
+            isModelLoaded = false
+            currentModel = nil
+            loadingProgress = 0
             lastError = error
             throw error
         }
@@ -281,6 +311,7 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
         isModelLoaded = false
         currentModel = nil
         loadingProgress = 0.0
+        lastError = nil
     }
     
     /// Generate a response using the loaded model

--- a/S2Y/LLM/LocalLLMService.swift
+++ b/S2Y/LLM/LocalLLMService.swift
@@ -155,6 +155,13 @@ public struct MockLLMContainer: LLMModelContainer {
 /// This is the main interface for local LLM operations
 @MainActor
 public final class LocalLLMService: ObservableObject, @unchecked Sendable {
+    private final class CachedModelContainer: NSObject {
+        let container: any LLMModelContainer
+
+        init(_ container: any LLMModelContainer) {
+            self.container = container
+        }
+    }
     
     // MARK: - Published Properties
     
@@ -179,7 +186,7 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
     private var modelContainer: (any LLMModelContainer)?
     
     /// Memory cache for model containers
-    private let containerCache = NSCache<NSString, NSMutableArray>()
+    private let containerCache = NSCache<NSString, CachedModelContainer>()
     
     /// System prompt for health context
     private var systemPrompt: String = """
@@ -231,15 +238,14 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
         
         // Try to load model from cache
         let cacheKey = config.rawValue as NSString
-        if let cachedContainers = containerCache.object(forKey: cacheKey) {
-            modelContainer = cachedContainers.first as? any LLMModelContainer
-            if modelContainer != nil {
-                loadingProgress = 1.0
-                progressHandler?(1.0)
-                isModelLoaded = true
-                currentModel = config
-                return
-            }
+        if let cachedContainer = containerCache.object(forKey: cacheKey) {
+            modelContainer = cachedContainer.container
+            loadingProgress = 1.0
+            progressHandler?(1.0)
+            isModelLoaded = true
+            currentModel = config
+            lastError = nil
+            return
         }
         
         // Load model (placeholder - actual implementation depends on backend)
@@ -252,6 +258,7 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
             progressHandler?(0.9)
             
             modelContainer = container
+            containerCache.setObject(CachedModelContainer(container), forKey: cacheKey)
             currentModel = config
             isModelLoaded = true
             loadingProgress = 1.0

--- a/S2YTests/LocalLLMServiceTests.swift
+++ b/S2YTests/LocalLLMServiceTests.swift
@@ -148,6 +148,23 @@ final class LocalLLMServiceTests: XCTestCase {
         // Just verify state is consistent
         XCTAssertNotNil(service)
     }
+
+#if targetEnvironment(simulator)
+    func testLoadModelRestoresUnloadedContainerFromMemoryCache() async throws {
+        try await service.loadModel(.tinyLlama)
+        await service.unloadModel()
+        var progress: [Double] = []
+
+        try await service.loadModel(.tinyLlama) { value in
+            progress.append(value)
+        }
+
+        XCTAssertTrue(service.isModelLoaded)
+        XCTAssertEqual(service.currentModel, .tinyLlama)
+        XCTAssertEqual(progress, [0.1, 1.0])
+        XCTAssertNil(service.lastError)
+    }
+#endif
     
     // MARK: - Unload Model Tests
     

--- a/S2YTests/LocalLLMServiceTests.swift
+++ b/S2YTests/LocalLLMServiceTests.swift
@@ -73,6 +73,7 @@ final class LocalLLMServiceTests: XCTestCase {
         XCTAssertFalse(service.isGenerating)
         XCTAssertEqual(service.loadingProgress, 0.0)
         XCTAssertNil(service.lastError)
+        XCTAssertEqual(service.state, .idle)
     }
     
     // MARK: - System Prompt Tests
@@ -163,8 +164,30 @@ final class LocalLLMServiceTests: XCTestCase {
         XCTAssertEqual(service.currentModel, .tinyLlama)
         XCTAssertEqual(progress, [0.1, 1.0])
         XCTAssertNil(service.lastError)
+        XCTAssertEqual(service.state, .ready(model: .tinyLlama))
     }
 #endif
+
+    func testInsufficientMemoryProducesConsistentFailedStateWhenApplicable() async throws {
+        let availableRAM = service.getAvailableRAM()
+        guard availableRAM < LocalModelConfig.mistralNemo.minRAM else {
+            throw XCTSkip("Device has enough memory for the largest configured model")
+        }
+
+        do {
+            try await service.loadModel(.mistralNemo)
+            XCTFail("Expected insufficient memory")
+        } catch let error as LocalLLMError {
+            XCTAssertEqual(
+                error,
+                .insufficientMemory(required: LocalModelConfig.mistralNemo.minRAM, available: availableRAM)
+            )
+            XCTAssertEqual(service.state, .failed(error))
+            XCTAssertFalse(service.isModelLoaded)
+            XCTAssertNil(service.currentModel)
+            XCTAssertEqual(service.loadingProgress, 0)
+        }
+    }
     
     // MARK: - Unload Model Tests
     
@@ -183,6 +206,8 @@ final class LocalLLMServiceTests: XCTestCase {
         XCTAssertFalse(service.isModelLoaded)
         XCTAssertNil(service.currentModel)
         XCTAssertEqual(service.loadingProgress, 0.0)
+        XCTAssertNil(service.lastError)
+        XCTAssertEqual(service.state, .idle)
     }
     
     // MARK: - Generate Tests

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1428,6 +1428,24 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertFalse(json.contains("resourceType"))
     }
 
+    func testAppleOnDeviceAvailabilityProvidesExplicitRecoveryWithoutAutomaticFallback() {
+        let states: [AppleFoundationModelAvailability] = [
+            .unavailable(.requiresNewerOS),
+            .unavailable(.deviceNotEligible),
+            .unavailable(.appleIntelligenceNotEnabled),
+            .unavailable(.modelNotReady),
+            .unavailable(.simulatorUnsupported),
+            .unavailable(.frameworkUnavailable)
+        ]
+
+        for state in states {
+            XCTAssertFalse(state.statusTitle.isEmpty)
+            XCTAssertFalse(state.recoveryGuidance.isEmpty)
+            XCTAssertFalse(state.recoveryGuidance.contains("Using Omer instead"))
+        }
+        XCTAssertEqual(AppleFoundationModelAvailability.available.statusTitle, "Ready")
+    }
+
     @MainActor
     func testClearingSharingReceiptsAlsoReturnsEveryScopeToDefaultDeny() {
         let suiteName = "HealthSharingConsentStoreTests.\(UUID().uuidString)"

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1444,6 +1444,14 @@ final class OmerMobileChatModelsTests: XCTestCase {
             XCTAssertFalse(state.recoveryGuidance.contains("Using Omer instead"))
         }
         XCTAssertEqual(AppleFoundationModelAvailability.available.statusTitle, "Ready")
+        XCTAssertTrue(
+            AppleFoundationModelAvailability.unavailable(.appleIntelligenceNotEnabled)
+                .recoveryGuidance.contains("iPhone Settings")
+        )
+        XCTAssertTrue(
+            AppleFoundationModelAvailability.unavailable(.modelNotReady)
+                .recoveryGuidance.contains("power and Wi-Fi")
+        )
     }
 
     @MainActor


### PR DESCRIPTION
## Theme

Make on-device AI state and recovery predictable without silently sending a local request online.

## Stories

- HLT-045: restore cached local model containers correctly
- HLT-046: model Apple on-device readiness and recovery states
- HLT-047: show actionable recovery while preserving manual provider choice
- HLT-048: keep loading, ready, failed, and unloaded states internally consistent

## Validation

- iPhone 17 simulator arm64 app build passed
- Full unit test suite passed (UI tests excluded)
- Local model cache restoration and state transition tests passed
- `git diff --check` passed

## Privacy behavior

An unavailable or interrupted on-device request is not automatically sent to Omer. The UI explicitly tells the user that the question stayed on the iPhone and requires a manual provider switch.