### PR TITLE
EPIC-H13: verifiable cloud data deletion

### DIFF
--- a/S2Y/Account/AccountSheet.swift
+++ b/S2Y/Account/AccountSheet.swift
@@ -28,6 +28,12 @@ struct AccountSheet: View {
                 if account.signedIn && !isInSetup {
                     AccountOverview(close: .showCloseButton) {
                         NavigationLink {
+                            CloudHealthDataLifecycleView()
+                        } label: {
+                            Text("Cloud Data and Deletion Scope")
+                        }
+
+                        NavigationLink {
                             ContributionsList(projectLicense: .mit)
                         } label: {
                             Text("License Information")

--- a/S2Y/DataControls/CloudHealthDataLifecycle.swift
+++ b/S2Y/DataControls/CloudHealthDataLifecycle.swift
@@ -1,0 +1,54 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+enum CloudHealthDataService: String, CaseIterable, Sendable, Identifiable {
+    case firebaseAccount
+    case omer
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .firebaseAccount: "S2Y account (Firebase)"
+        case .omer: "Omer AI"
+        }
+    }
+}
+
+enum CloudHealthDataDeletionScope: Sendable, Equatable {
+    case account
+    case individualConversation
+}
+
+struct CloudHealthDataCapability: Sendable, Equatable, Identifiable {
+    let service: CloudHealthDataService
+    let storedDataDescription: String
+    let deletionScope: CloudHealthDataDeletionScope
+    let deletionEntryPoint: String
+
+    var id: CloudHealthDataService { service }
+}
+
+enum CloudHealthDataLifecycle {
+    static let capabilities = [
+        CloudHealthDataCapability(
+            service: .firebaseAccount,
+            storedDataDescription: "Account profile, authorized questionnaire backups, and synchronized app records",
+            deletionScope: .account,
+            deletionEntryPoint: "Account settings"
+        ),
+        CloudHealthDataCapability(
+            service: .omer,
+            storedDataDescription: "Online conversations and explicitly synchronized on-device conversations",
+            deletionScope: .individualConversation,
+            deletionEntryPoint: "Chat drawer"
+        )
+    ]
+}

--- a/S2Y/DataControls/CloudHealthDataLifecycleView.swift
+++ b/S2Y/DataControls/CloudHealthDataLifecycleView.swift
@@ -1,0 +1,47 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct CloudHealthDataLifecycleView: View {
+    var body: some View {
+        List {
+            ForEach(CloudHealthDataLifecycle.capabilities) { capability in
+                Section(capability.service.title) {
+                    LabeledContent("May contain") {
+                        Text(capability.storedDataDescription)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    LabeledContent("Deletion scope", value: deletionScope(capability.deletionScope))
+                    LabeledContent("Where to delete", value: capability.deletionEntryPoint)
+                }
+            }
+
+            Section("Before deleting an account") {
+                Text(
+                    "Export any local information you want to keep first. "
+                        + "Deleting the Firebase account removes Firebase-owned account data, "
+                        + "but does not claim to delete Apple Health or Omer conversations."
+                )
+                Text(
+                    "Delete Omer conversations from the chat drawer. "
+                        + "Then use Manage Account to review Firebase account deletion."
+                )
+            }
+        }
+        .navigationTitle("Cloud Data")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func deletionScope(_ scope: CloudHealthDataDeletionScope) -> String {
+        switch scope {
+        case .account: "Whole account"
+        case .individualConversation: "One conversation at a time"
+        }
+    }
+}

--- a/S2Y/DataControls/LocalHealthDataControlsView.swift
+++ b/S2Y/DataControls/LocalHealthDataControlsView.swift
@@ -146,8 +146,11 @@ struct LocalHealthDataControlsView: View {
 
     private var cloudBoundarySection: some View {
         Section("Cloud data") {
-            Label("Firebase account copies", systemImage: "person.crop.circle.badge.checkmark")
-            Label("Omer conversations", systemImage: "bubble.left.and.bubble.right")
+            NavigationLink {
+                CloudHealthDataLifecycleView()
+            } label: {
+                Label("Review Cloud Data and Deletion", systemImage: "cloud")
+            }
 
             Text(
                 "Local deletion never sends a remote deletion request. "

--- a/S2Y/HomeView.swift
+++ b/S2Y/HomeView.swift
@@ -79,6 +79,9 @@ struct HomeView: View {
     @State private var requestedConversationID: UUID?
     @State private var newChatRequestID = UUID()
     @State private var isRefreshingChatHistory = false
+    @State private var chatPendingDeletion: OmerChatSummary?
+    @State private var chatDeletionError: String?
+    @State private var isDeletingChat = false
 
 
     var body: some View {
@@ -107,6 +110,23 @@ struct HomeView: View {
         .onChange(of: isDrawerOpen) {
             guard isDrawerOpen else { return }
             Task { await loadDrawerChatHistory() }
+        }
+        .confirmationDialog(
+            "Delete this Omer conversation?",
+            isPresented: Binding(
+                get: { chatPendingDeletion != nil },
+                set: { if !$0 { chatPendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete from Omer", role: .destructive) {
+                guard let chat = chatPendingDeletion else { return }
+                chatPendingDeletion = nil
+                Task { await deleteChat(chat) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This removes the conversation from Omer and from this iPhone's chat cache. It cannot be undone.")
         }
     }
 
@@ -163,6 +183,14 @@ struct HomeView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 10) {
                     newChatButton
+
+                    if let chatDeletionError {
+                        Text(chatDeletionError)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 24)
+                            .accessibilityIdentifier("drawer.chat-delete-error")
+                    }
 
                     if drawerChatHistory.isEmpty {
                         Text("Recent chats")
@@ -278,26 +306,41 @@ struct HomeView: View {
     }
 
     private func drawerChatRow(_ chat: OmerChatSummary) -> some View {
-        Button {
-            selectedTab = .healthAssistant
-            requestedConversationID = chat.id
-            closeDrawer()
-        } label: {
-            HStack(spacing: 10) {
-                Image(systemName: "bubble.left")
-                    .foregroundStyle(.secondary)
-                Text(chat.title)
-                    .font(.subheadline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(2)
-                Spacer(minLength: 8)
+        HStack(spacing: 8) {
+            Button {
+                selectedTab = .healthAssistant
+                requestedConversationID = chat.id
+                closeDrawer()
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "bubble.left")
+                        .foregroundStyle(.secondary)
+                    Text(chat.title)
+                        .font(.subheadline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                    Spacer(minLength: 8)
+                }
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("drawer.chat.\(chat.id.uuidString)")
+
+            Button {
+                chatPendingDeletion = chat
+            } label: {
+                Image(systemName: "ellipsis")
+                    .frame(width: 36, height: 36)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isDeletingChat)
+            .accessibilityLabel("Conversation actions for \(chat.title)")
+            .accessibilityIdentifier("drawer.chat-actions.\(chat.id.uuidString)")
         }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("drawer.chat.\(chat.id.uuidString)")
+        .padding(.leading, 20)
+        .padding(.trailing, 14)
+        .padding(.vertical, 4)
     }
 
     private func drawerRow(for tab: Tabs) -> some View {
@@ -377,6 +420,24 @@ struct HomeView: View {
         defer { isRefreshingChatHistory = false }
         if let remoteChats = try? await OmerChatService.shared.fetchChats(limit: 50).chats {
             drawerChatHistory = remoteChats
+        }
+    }
+
+    @MainActor
+    private func deleteChat(_ chat: OmerChatSummary) async {
+        isDeletingChat = true
+        chatDeletionError = nil
+        defer { isDeletingChat = false }
+
+        do {
+            try await OmerChatService.shared.deleteChat(id: chat.id)
+            drawerChatHistory.removeAll { $0.id == chat.id }
+            if requestedConversationID == chat.id {
+                requestedConversationID = nil
+                newChatRequestID = UUID()
+            }
+        } catch {
+            chatDeletionError = "\(chat.title) was not deleted from Omer. Check your connection and try again."
         }
     }
 }

--- a/S2Y/LLM/Omer/OmerChatModels.swift
+++ b/S2Y/LLM/Omer/OmerChatModels.swift
@@ -199,6 +199,11 @@ struct OmerChatDetailResponse: Codable, Sendable {
 struct OmerChatCacheSnapshot: Codable, Sendable {
     var chats: [OmerChatSummary]
     var details: [OmerChatDetailResponse]
+
+    mutating func removeChat(id: UUID) {
+        chats.removeAll { $0.id == id }
+        details.removeAll { $0.chat.id == id }
+    }
 }
 
 struct OmerAPIErrorResponse: Decodable {

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -190,6 +190,17 @@ actor OmerChatService {
         return detail
     }
 
+    func deleteChat(id: UUID) async throws {
+        let serviceURL = try configuredServiceURL()
+        let url = serviceURL
+            .appendingPathComponent("api/mobile/v1/chats")
+            .appendingPathComponent(id.uuidString)
+        try await authenticatedDELETE(url: url)
+        chatCache.removeChat(id: id)
+        persistCache()
+        await sessionStore.saveLastChatId(nil, sessionKey: sessionKey(for: serviceURL))
+    }
+
     func cachedChats(limit: Int = 50) -> [OmerChatSummary] {
         Array(chatCache.chats.prefix(max(1, limit)))
     }
@@ -389,6 +400,24 @@ actor OmerChatService {
         } catch OmerChatServiceError.unauthorized {
             return try await performAuthenticatedGET(url: url, forceTokenRefresh: true)
         }
+    }
+
+    private func authenticatedDELETE(url: URL) async throws {
+        do {
+            try await performAuthenticatedDELETE(url: url, forceTokenRefresh: false)
+        } catch OmerChatServiceError.unauthorized {
+            try await performAuthenticatedDELETE(url: url, forceTokenRefresh: true)
+        }
+    }
+
+    private func performAuthenticatedDELETE(url: URL, forceTokenRefresh: Bool) async throws {
+        let token = try await firebaseIDToken(forceRefresh: forceTokenRefresh)
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, data: data)
     }
 
     private func performAuthenticatedGET(url: URL, forceTokenRefresh: Bool) async throws -> Data {

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1471,6 +1471,35 @@ final class OmerMobileChatModelsTests: XCTestCase {
         )
     }
 
+    func testOmerCacheRemovalDeletesSummaryAndMessagesTogether() {
+        let deletedID = UUID()
+        let retainedID = UUID()
+        let deleted = OmerChatSummary(
+            id: deletedID,
+            createdAt: "2026-08-12T18:00:00Z",
+            title: "Delete me",
+            visibility: "private"
+        )
+        let retained = OmerChatSummary(
+            id: retainedID,
+            createdAt: "2026-08-11T18:00:00Z",
+            title: "Keep me",
+            visibility: "private"
+        )
+        var snapshot = OmerChatCacheSnapshot(
+            chats: [deleted, retained],
+            details: [
+                OmerChatDetailResponse(chat: deleted, messages: []),
+                OmerChatDetailResponse(chat: retained, messages: [])
+            ]
+        )
+
+        snapshot.removeChat(id: deletedID)
+
+        XCTAssertEqual(snapshot.chats.map(\.id), [retainedID])
+        XCTAssertEqual(snapshot.details.map(\.chat.id), [retainedID])
+    }
+
     @MainActor
     func testClearingSharingReceiptsAlsoReturnsEveryScopeToDefaultDeny() {
         let suiteName = "HealthSharingConsentStoreTests.\(UUID().uuidString)"

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1454,6 +1454,23 @@ final class OmerMobileChatModelsTests: XCTestCase {
         )
     }
 
+    func testCloudDataLifecycleDeclaresVerifiedDeletionEntryPoints() {
+        XCTAssertEqual(CloudHealthDataLifecycle.capabilities.count, 2)
+        XCTAssertEqual(
+            CloudHealthDataLifecycle.capabilities.first { $0.service == .firebaseAccount }?.deletionScope,
+            .account
+        )
+        XCTAssertEqual(
+            CloudHealthDataLifecycle.capabilities.first { $0.service == .omer }?.deletionScope,
+            .individualConversation
+        )
+        XCTAssertTrue(
+            CloudHealthDataLifecycle.capabilities.allSatisfy {
+                !$0.storedDataDescription.isEmpty && !$0.deletionEntryPoint.isEmpty
+            }
+        )
+    }
+
     @MainActor
     func testClearingSharingReceiptsAlsoReturnsEveryScopeToDefaultDeny() {
         let suiteName = "HealthSharingConsentStoreTests.\(UUID().uuidString)"


### PR DESCRIPTION
## Theme

Connect only verified cloud deletion capabilities and make local-versus-remote outcomes explicit.

## Stories

- HLT-049: map Firebase and Omer storage/deletion scopes
- HLT-050: delete an owned Omer conversation through the mobile API
- HLT-051: explain Firebase account and Omer conversation deletion boundaries
- HLT-052: keep local state intact and show an error when remote deletion fails

## Validation

- Verified Omer mobile DELETE route ownership check and 204 contract in local upstream source
- iPhone 17 simulator arm64 app build passed
- Full unit test suite passed (UI tests excluded)
- `git diff --check` passed

## Integrity behavior

The iOS cache is changed only after Omer confirms deletion. Firebase account deletion does not claim to remove Omer or Apple Health data.