### PR TITLE
EPIC-H14: Swift 6 runtime safety

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantView+LocalModel 2.swift
+++ b/S2Y/HealthAssistant/HealthAssistantView+LocalModel 2.swift
@@ -5,7 +5,7 @@ extension HealthAssistantView {
     @MainActor
     final class LocalModelBridge: ObservableObject {
         @Published private(set) var isReady = false
-        @Published private(set) var lastError: Error?
+        @Published private(set) var lastError: (any Error)?
         
         private let orchestrator = LLMOrchestrator.shared
         

--- a/S2Y/HealthAssistant/LLMOrchestrator.swift
+++ b/S2Y/HealthAssistant/LLMOrchestrator.swift
@@ -14,7 +14,7 @@ final class LLMOrchestrator: ObservableObject {
     // State (optional observables)
     @Published private(set) var isLocalLoaded: Bool = false
     @Published private(set) var currentLocalModel: LocalModelConfig?
-    @Published private(set) var lastError: Error?
+    @Published private(set) var lastError: (any Error)?
     
     private init() {}
     
@@ -22,14 +22,9 @@ final class LLMOrchestrator: ObservableObject {
     
     /// Complete a message using local model if available, otherwise fall back to cloud.
     func complete(message: String, includeContext: Bool) async throws -> LLMResponse {
-        // If we're in environments that only provide mock local backends, bypass local and use cloud
-        #if DEBUG
-        return try await cloudProvider.sendMessage(message, includeContext: includeContext)
-        #else
-        #if targetEnvironment(simulator)
-        return try await cloudProvider.sendMessage(message, includeContext: includeContext)
-        #endif
-        #endif
+        if shouldBypassLegacyLocalBackend {
+            return try await cloudProvider.sendMessage(message, includeContext: includeContext)
+        }
         
         // Ensure local model is prepared (lazy)
         if !localService.isModelLoaded {
@@ -61,21 +56,19 @@ final class LLMOrchestrator: ObservableObject {
     /// Prepare a local model (optional preloading). Automatically selects a model based on available RAM.
     func prepareLocalModelIfNeeded() async {
         guard !localService.isModelLoaded else {
-            await MainActor.run { self.isLocalLoaded = true }
+            isLocalLoaded = true
             return
         }
         
         let target = selectModelForDevice()
         do {
             try await localService.loadModel(target)
-            await MainActor.run {
-                self.isLocalLoaded = self.localService.isModelLoaded
-                self.currentLocalModel = target
-                self.lastError = nil
-            }
+            isLocalLoaded = localService.isModelLoaded
+            currentLocalModel = target
+            lastError = nil
             logger.info("Local model loaded: \(target.rawValue)")
         } catch {
-            await MainActor.run { self.lastError = error }
+            lastError = error
             logger.error("Failed to load local model: \(error.localizedDescription)")
         }
     }
@@ -83,10 +76,8 @@ final class LLMOrchestrator: ObservableObject {
     /// Unload local model to free memory
     func unloadLocalModel() async {
         await localService.unloadModel()
-        await MainActor.run {
-            self.isLocalLoaded = false
-            self.currentLocalModel = nil
-        }
+        isLocalLoaded = false
+        currentLocalModel = nil
     }
     
     // MARK: - Model selection
@@ -97,5 +88,14 @@ final class LLMOrchestrator: ObservableObject {
         if ramGB >= 8 { return .llama3_8b }
         return .phi4Mini
     }
-}
 
+    private var shouldBypassLegacyLocalBackend: Bool {
+        #if DEBUG
+        true
+        #elseif targetEnvironment(simulator)
+        true
+        #else
+        false
+        #endif
+    }
+}

--- a/S2Y/LLM/ChatHistoryManager.swift
+++ b/S2Y/LLM/ChatHistoryManager.swift
@@ -390,7 +390,7 @@ extension HealthInsight: Codable {
         case title, titleCN, description, descriptionCN, type, importance, metric
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         title = try container.decode(String.self, forKey: .title)
         titleCN = try container.decode(String.self, forKey: .titleCN)
@@ -401,7 +401,7 @@ extension HealthInsight: Codable {
         metric = try container.decodeIfPresent(HealthKitService.MetricKind.self, forKey: .metric)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(title, forKey: .title)
         try container.encode(titleCN, forKey: .titleCN)

--- a/S2Y/LLM/EnhancedLLMProvider+LocalModel_Simplified.swift
+++ b/S2Y/LLM/EnhancedLLMProvider+LocalModel_Simplified.swift
@@ -337,7 +337,7 @@ struct LocalModelStatus_Simplified {
     let isLoaded: Bool
     let status: LocalHealthModelManager_Simplified.ModelStatus
     let loadingProgress: Double
-    let lastError: LocalizedError?
+    let lastError: (any LocalizedError)?
     
     public var statusDescription: String {
         switch status {

--- a/S2Y/LLM/EnhancedLLMProvider.swift
+++ b/S2Y/LLM/EnhancedLLMProvider.swift
@@ -368,7 +368,7 @@ public enum LLMError: Error, LocalizedError {
     case authenticationFailed
     case invalidResponse
     case serverError(Int)
-    case unknown(Error)
+    case unknown(any Error)
     
     public var errorDescription: String? {
         switch self {

--- a/S2Y/LLM/LocalLLMService.swift
+++ b/S2Y/LLM/LocalLLMService.swift
@@ -122,7 +122,7 @@ public struct LocalGenerateParameters: Sendable {
 /// Protocol for underlying model implementation
 /// Allows swapping between MLX, llama.cpp, CoreML backends
 public protocol LLMModelContainer: Sendable {
-    func generate(prompt: String, parameters: LocalGenerateParameters) -> AsyncThrowingStream<String, Error>
+    func generate(prompt: String, parameters: LocalGenerateParameters) -> AsyncThrowingStream<String, any Error>
 }
 
 // ============================================================
@@ -132,7 +132,7 @@ public protocol LLMModelContainer: Sendable {
 /// A lightweight mock container to validate the end-to-end pipeline in Simulator
 public struct MockLLMContainer: LLMModelContainer {
     public init() {}
-    public func generate(prompt: String, parameters: LocalGenerateParameters) -> AsyncThrowingStream<String, Error> {
+    public func generate(prompt: String, parameters: LocalGenerateParameters) -> AsyncThrowingStream<String, any Error> {
         AsyncThrowingStream { continuation in
             Task {
                 // Simulate token-by-token streaming
@@ -322,7 +322,7 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
     public func generate(
         prompt: String,
         parameters: LocalGenerateParameters = LocalGenerateParameters()
-    ) -> AsyncThrowingStream<String, Error> {
+    ) -> AsyncThrowingStream<String, any Error> {
         AsyncThrowingStream { [weak self] continuation in
             Task { [weak self] in
                 guard let self = self else {
@@ -379,7 +379,7 @@ public final class LocalLLMService: ObservableObject, @unchecked Sendable {
     
     /// Quick smoke test to validate local model pipeline on Simulator/Device
     @discardableResult
-    public func runSmokeTest(prompt: String = "Hello, how are my steps today?") async -> Result<String, Error> {
+    public func runSmokeTest(prompt: String = "Hello, how are my steps today?") async -> Result<String, any Error> {
         do {
             try await loadModel(.phi3_5Mini)
             let output = try await generateComplete(prompt: prompt, parameters: LocalGenerateParameters(maxTokens: 64))

--- a/S2Y/LocalModel/LocalHealthModelManager.swift
+++ b/S2Y/LocalModel/LocalHealthModelManager.swift
@@ -25,7 +25,7 @@ class LocalHealthModelManager {
     private(set) var isModelLoaded = false
     private(set) var loadingProgress: Double = 0.0
     private(set) var modelStatus: ModelStatus = .notLoaded
-    private(set) var lastError: LocalizedError?
+    private(set) var lastError: (any LocalizedError)?
     
     // MARK: - Private Properties
     private var model: LMModel?

--- a/S2Y/LocalModel/LocalHealthModelManager_Simplified.swift
+++ b/S2Y/LocalModel/LocalHealthModelManager_Simplified.swift
@@ -22,7 +22,7 @@ class LocalHealthModelManager_Simplified {
     private(set) var isModelLoaded = false
     private(set) var loadingProgress: Double = 0.0
     private(set) var modelStatus: ModelStatus = .notLoaded
-    private(set) var lastError: LocalizedError?
+    private(set) var lastError: (any LocalizedError)?
     
     // MARK: - Private Properties
     private let logger = Logger(subsystem: "S2Y", category: "LocalModel")
@@ -114,7 +114,7 @@ class LocalHealthModelManager_Simplified {
             
         } catch {
             logger.error("❌ Failed to load model: \(error.localizedDescription)")
-            if let le = error as? LocalizedError {
+            if let le = error as? any LocalizedError {
                 lastError = le
             } else {
                 lastError = ModelError.loadingFailed(error.localizedDescription)
@@ -130,7 +130,7 @@ class LocalHealthModelManager_Simplified {
         }
         
         guard isModelLoaded, case .loaded = modelStatus else {
-            throw ModelError.modelNotLoaded as Error
+            throw ModelError.modelNotLoaded as any Error
         }
     }
     

--- a/S2Y/LocalModel/MLXModelDownloadManager.swift
+++ b/S2Y/LocalModel/MLXModelDownloadManager.swift
@@ -433,7 +433,9 @@ final class MLXModelDownloadManager: ObservableObject {
     
     private func startProgressTimer() {
         progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.updateProgress()
+            Task { @MainActor [weak self] in
+                self?.updateProgress()
+            }
         }
     }
     

--- a/S2Y/LocalModel/ModelMemoryMonitor.swift
+++ b/S2Y/LocalModel/ModelMemoryMonitor.swift
@@ -13,7 +13,8 @@ import Darwin.Mach
 
 /// 模型内存监控器
 /// 负责监控设备内存状态，确保本地模型安全运行
-class ModelMemoryMonitor {
+@MainActor
+final class ModelMemoryMonitor {
     private let logger = Logger(subsystem: "S2Y", category: "MemoryMonitor")
     
     /// 检查是否有足够内存加载模型
@@ -75,25 +76,33 @@ class ModelMemoryMonitor {
     }
     
     /// 注册内存警告观察者
-    func registerMemoryWarningObserver(callback: @escaping () -> Void) {
+    func registerMemoryWarningObserver(callback: @escaping @MainActor @Sendable () -> Void) {
         NotificationCenter.default.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,
             object: nil,
             queue: .main
-        ) { _ in
-            self.logger.warning("Memory warning received from system")
-            callback()
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.logger.warning("Memory warning received from system")
+                callback()
+            }
         }
     }
     
     /// 监控内存使用情况
-    func startMemoryMonitoring(interval: TimeInterval = 30.0, callback: @escaping (MemoryStatus) -> Void) {
-        Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-            let status = self.getCurrentMemoryStatus()
-            callback(status)
-            
-            if status.pressureLevel == .high || status.pressureLevel == .critical {
-                self.logger.warning("High memory pressure detected: \(status)")
+    func startMemoryMonitoring(
+        interval: TimeInterval = 30.0,
+        callback: @escaping @MainActor @Sendable (MemoryStatus) -> Void
+    ) {
+        Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                let status = self.getCurrentMemoryStatus()
+                callback(status)
+
+                if status.pressureLevel == .high || status.pressureLevel == .critical {
+                    self.logger.warning("High memory pressure detected: \(status)")
+                }
             }
         }
     }


### PR DESCRIPTION
## Theme

Remove confirmed concurrency and future Swift-language hazards around local AI runtime components without changing provider behavior.

## Stories

- HLT-053: keep local/cloud provider routing branches reachable in every build configuration
- HLT-054: update model download progress only on the main actor
- HLT-055: isolate memory monitoring and require Sendable callbacks
- HLT-056: adopt explicit Swift 6 existential types across the affected runtime path

## Validation

- iPhone 17 simulator arm64 app build passed
- Full unit test suite passed (UI tests excluded)
- Targeted unreachable-code, actor-isolation, Sendable-capture, and existential warnings no longer appear
- `git diff --check` passed