### PR TITLE
EPIC-H15: stable local history persistence

### DIFF
--- a/S2Y/LLM/ChatHistoryManager.swift
+++ b/S2Y/LLM/ChatHistoryManager.swift
@@ -195,24 +195,9 @@ public final class ChatHistoryManager: ObservableObject {
     /// Import conversation data
     public func importConversationData(_ data: Data) async throws {
         let importData = try JSONDecoder().decode(ChatExportData.self, from: data)
-        
-        // Merge imported conversations (avoid duplicates)
-        for importedConv in importData.conversations {
-            if !conversations.contains(where: { $0.id == importedConv.id }) {
-                conversations.append(importedConv)
-            }
-        }
-        
-        // Merge imported favorites
-        for importedFav in importData.favoriteInsights {
-            if !favoriteInsights.contains(where: { $0.id == importedFav.id }) {
-                favoriteInsights.append(importedFav)
-            }
-        }
-        
-        // Sort by date
-        conversations.sort { $0.lastActivity > $1.lastActivity }
-        favoriteInsights.sort { $0.savedAt > $1.savedAt }
+
+        conversations = ChatHistoryNormalization.conversations(conversations + importData.conversations)
+        favoriteInsights = ChatHistoryNormalization.favorites(favoriteInsights + importData.favoriteInsights)
         
         // Apply limits
         cleanupOldConversations()
@@ -244,8 +229,8 @@ public final class ChatHistoryManager: ObservableObject {
     
     private func cleanupOldConversations() {
         let cutoffDate = Date().addingTimeInterval(-maxConversationAge)
-        
-        // Remove old conversations
+
+        conversations = ChatHistoryNormalization.conversations(conversations)
         conversations.removeAll { $0.lastActivity < cutoffDate }
         
         // Limit number of conversations
@@ -270,7 +255,7 @@ public final class ChatHistoryManager: ObservableObject {
                 let loadedConversations = try JSONDecoder().decode([StoredConversation].self, from: data)
                 
                 await MainActor.run {
-                    self.conversations = loadedConversations
+                    self.conversations = ChatHistoryNormalization.conversations(loadedConversations)
                     self.cleanupOldConversations()
                 }
                 
@@ -288,7 +273,7 @@ public final class ChatHistoryManager: ObservableObject {
                 let loadedFavorites = try JSONDecoder().decode([FavoriteInsight].self, from: data)
                 
                 await MainActor.run {
-                    self.favoriteInsights = loadedFavorites
+                    self.favoriteInsights = ChatHistoryNormalization.favorites(loadedFavorites)
                 }
                 
                 logger.info("Loaded \(loadedFavorites.count) favorite insights from storage")
@@ -316,6 +301,24 @@ public final class ChatHistoryManager: ObservableObject {
         } catch {
             logger.error("Failed to save favorite insights: \(error)")
         }
+    }
+}
+
+enum ChatHistoryNormalization {
+    static func conversations(_ values: [StoredConversation]) -> [StoredConversation] {
+        Dictionary(grouping: values, by: \.id)
+            .compactMap { _, duplicates in
+                duplicates.max { $0.lastActivity < $1.lastActivity }
+            }
+            .sorted { $0.lastActivity > $1.lastActivity }
+    }
+
+    static func favorites(_ values: [FavoriteInsight]) -> [FavoriteInsight] {
+        Dictionary(grouping: values, by: \.id)
+            .compactMap { _, duplicates in
+                duplicates.max { $0.savedAt < $1.savedAt }
+            }
+            .sorted { $0.savedAt > $1.savedAt }
     }
 }
 

--- a/S2Y/LLM/ChatHistoryManager.swift
+++ b/S2Y/LLM/ChatHistoryManager.swift
@@ -5,6 +5,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import CryptoKit
 import Foundation
 import OSLog
 
@@ -361,6 +362,23 @@ public struct StoredMessage: Identifiable, Codable {
         self.timestamp = timestamp
         self.metadata = metadata
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, role, content, timestamp, metadata
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        role = try container.decode(MessageRole.self, forKey: .role)
+        content = try container.decode(String.self, forKey: .content)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        metadata = try container.decodeIfPresent(MessageMetadata.self, forKey: .metadata)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id)
+            ?? LegacyChatHistoryIdentifier.make(
+                namespace: "message",
+                components: [role.rawValue, content, timestamp.timeIntervalSince1970.description]
+            )
+    }
 }
 
 public struct StoredInsight: Identifiable, Codable {
@@ -383,6 +401,23 @@ public struct StoredInsight: Identifiable, Codable {
         self.timestamp = timestamp
         self.confidence = confidence
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, content, type, timestamp, confidence
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decode(String.self, forKey: .content)
+        type = try container.decode(String.self, forKey: .type)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        confidence = try container.decode(Double.self, forKey: .confidence)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id)
+            ?? LegacyChatHistoryIdentifier.make(
+                namespace: "insight",
+                components: [content, type, timestamp.timeIntervalSince1970.description]
+            )
+    }
 }
 
 public struct FavoriteInsight: Identifiable, Codable {
@@ -401,6 +436,37 @@ public struct FavoriteInsight: Identifiable, Codable {
         self.insight = insight
         self.conversationId = conversationId
         self.savedAt = savedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, insight, conversationId, savedAt
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        insight = try container.decode(HealthInsight.self, forKey: .insight)
+        conversationId = try container.decode(UUID.self, forKey: .conversationId)
+        savedAt = try container.decode(Date.self, forKey: .savedAt)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id)
+            ?? LegacyChatHistoryIdentifier.make(
+                namespace: "favorite",
+                components: [conversationId.uuidString, insight.title, savedAt.timeIntervalSince1970.description]
+            )
+    }
+}
+
+private enum LegacyChatHistoryIdentifier {
+    static func make(namespace: String, components: [String]) -> UUID {
+        let digest = SHA256.hash(data: Data(([namespace] + components).joined(separator: "\u{1F}").utf8))
+        var bytes = Array(digest.prefix(16))
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 }
 

--- a/S2Y/LLM/ChatHistoryManager.swift
+++ b/S2Y/LLM/ChatHistoryManager.swift
@@ -342,26 +342,66 @@ public struct StoredConversation: Identifiable, Codable {
 }
 
 public struct StoredMessage: Identifiable, Codable {
-    public let id = UUID()
+    public let id: UUID
     public let role: MessageRole
     public let content: String
     public let timestamp: Date
     public let metadata: MessageMetadata?
+
+    public init(
+        id: UUID = UUID(),
+        role: MessageRole,
+        content: String,
+        timestamp: Date,
+        metadata: MessageMetadata?
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+        self.metadata = metadata
+    }
 }
 
 public struct StoredInsight: Identifiable, Codable {
-    public let id = UUID()
+    public let id: UUID
     public let content: String
     public let type: String
     public let timestamp: Date
     public let confidence: Double
+
+    public init(
+        id: UUID = UUID(),
+        content: String,
+        type: String,
+        timestamp: Date,
+        confidence: Double
+    ) {
+        self.id = id
+        self.content = content
+        self.type = type
+        self.timestamp = timestamp
+        self.confidence = confidence
+    }
 }
 
 public struct FavoriteInsight: Identifiable, Codable {
-    public let id = UUID()
+    public let id: UUID
     public let insight: HealthInsight
     public let conversationId: UUID
     public let savedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        insight: HealthInsight,
+        conversationId: UUID,
+        savedAt: Date
+    ) {
+        self.id = id
+        self.insight = insight
+        self.conversationId = conversationId
+        self.savedAt = savedAt
+    }
 }
 
 public struct ChatStatistics {

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -1500,6 +1500,75 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertEqual(snapshot.details.map(\.chat.id), [retainedID])
     }
 
+    func testStoredHistoryIdentifiersSurviveRoundTrip() throws {
+        let messageID = UUID()
+        let insightID = UUID()
+        let favoriteID = UUID()
+        let message = StoredMessage(
+            id: messageID,
+            role: .user,
+            content: "How was my sleep?",
+            timestamp: .now,
+            metadata: nil
+        )
+        let insight = StoredInsight(
+            id: insightID,
+            content: "Sleep duration was consistent.",
+            type: "insight",
+            timestamp: .now,
+            confidence: 0.8
+        )
+        let favorite = FavoriteInsight(
+            id: favoriteID,
+            insight: HealthInsight(
+                title: "Consistent sleep",
+                titleCN: "睡眠稳定",
+                description: "Descriptive observation",
+                descriptionCN: "描述性观察",
+                type: .trend,
+                importance: 0.7
+            ),
+            conversationId: UUID(),
+            savedAt: .now
+        )
+
+        XCTAssertEqual(try decoder.decode(StoredMessage.self, from: encoder.encode(message)).id, messageID)
+        XCTAssertEqual(try decoder.decode(StoredInsight.self, from: encoder.encode(insight)).id, insightID)
+        XCTAssertEqual(try decoder.decode(FavoriteInsight.self, from: encoder.encode(favorite)).id, favoriteID)
+    }
+
+    func testLegacyHistoryWithoutIDsReceivesDeterministicIdentifiers() throws {
+        let original = StoredMessage(
+            role: .assistant,
+            content: "A stable legacy message",
+            timestamp: Date(timeIntervalSince1970: 1_786_560_000),
+            metadata: nil
+        )
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoder.encode(original)) as? [String: Any]
+        )
+        object.removeValue(forKey: "id")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+
+        let first = try decoder.decode(StoredMessage.self, from: legacyData)
+        let second = try decoder.decode(StoredMessage.self, from: legacyData)
+
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertEqual(first.content, original.content)
+    }
+
+    func testHistoryNormalizationKeepsNewestDuplicateAndSorts() {
+        let duplicateID = UUID()
+        let older = storedConversation(id: duplicateID, lastActivity: Date(timeIntervalSince1970: 10))
+        let newer = storedConversation(id: duplicateID, lastActivity: Date(timeIntervalSince1970: 30))
+        let middle = storedConversation(id: UUID(), lastActivity: Date(timeIntervalSince1970: 20))
+
+        let normalized = ChatHistoryNormalization.conversations([older, middle, newer])
+
+        XCTAssertEqual(normalized.count, 2)
+        XCTAssertEqual(normalized.map(\.lastActivity), [newer.lastActivity, middle.lastActivity])
+    }
+
     @MainActor
     func testClearingSharingReceiptsAlsoReturnsEveryScopeToDefaultDeny() {
         let suiteName = "HealthSharingConsentStoreTests.\(UUID().uuidString)"
@@ -1525,6 +1594,20 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertTrue(HealthSharingConsentPolicy.permits(.omerChatText, authorization: authorization))
         XCTAssertFalse(
             HealthSharingConsentPolicy.permits(.onDeviceConversationSync, authorization: authorization)
+        )
+    }
+
+    private func storedConversation(id: UUID, lastActivity: Date) -> StoredConversation {
+        StoredConversation(
+            id: id,
+            title: "Conversation",
+            startTime: lastActivity.addingTimeInterval(-60),
+            lastActivity: lastActivity,
+            messageCount: 0,
+            messages: [],
+            topics: [],
+            healthMetricsDiscussed: [],
+            insights: []
         )
     }
 


### PR DESCRIPTION
## User stories
- HLT-057 persists stable identifiers for messages, insights, and favorites
- HLT-058 deterministically migrates legacy history records that lack identifiers
- HLT-059 deduplicates persisted conversations and favorites while keeping the newest record
- HLT-060 verifies identity round trips, legacy migration, and normalization

## Validation
- iOS Simulator app build (iPhone 17, arm64)
- full S2Y unit test suite (UI tests excluded)
- focused OmerMobileChatModelsTests
- git diff --check

## Data integrity
Existing local records remain readable. Missing identifiers are derived deterministically from record content; no health data is uploaded or changed remotely.