### PR TITLE
EPIC-H16: modernize iOS platform APIs

### DIFF
--- a/S2Y/HealthAssistant/EnhancedHealthAssistantView.swift
+++ b/S2Y/HealthAssistant/EnhancedHealthAssistantView.swift
@@ -141,7 +141,7 @@ struct EnhancedHealthAssistantView: View {
                 }
                 .padding()
             }
-            .onChange(of: messages.count) { _ in
+            .onChange(of: messages.count) {
                 if let lastMessage = messages.last {
                     withAnimation(.easeInOut(duration: 0.3)) {
                         proxy.scrollTo(lastMessage.id, anchor: .bottom)

--- a/S2Y/HealthAssistant/SpeechManager.swift
+++ b/S2Y/HealthAssistant/SpeechManager.swift
@@ -37,7 +37,7 @@ final class SpeechManager: ObservableObject {
         authorizationGranted = speechStatus == .authorized
 
         let micGranted = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+            AVAudioApplication.requestRecordPermission { granted in
                 continuation.resume(returning: granted)
             }
         }
@@ -77,7 +77,11 @@ final class SpeechManager: ObservableObject {
             throw NSError(domain: "SpeechManager", code: -13, userInfo: [NSLocalizedDescriptionKey: "No available audio input. Please connect a microphone or enable audio input routing."])
         }
         do {
-            try audioSession.setCategory(.playAndRecord, mode: .default, options: [.duckOthers, .defaultToSpeaker, .allowBluetooth])
+            try audioSession.setCategory(
+                .playAndRecord,
+                mode: .default,
+                options: [.duckOthers, .defaultToSpeaker, .allowBluetoothHFP]
+            )
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             cleanupOnFailure()
@@ -172,4 +176,3 @@ final class SpeechManager: ObservableObject {
         synthesizer.speak(utterance)
     }
 }
-

--- a/S2Y/HealthKit/CardiacAnalytics.swift
+++ b/S2Y/HealthKit/CardiacAnalytics.swift
@@ -127,9 +127,6 @@ public final class CardiacAnalytics {
     public func generateCardiacProfile(windowDays: Int = 30) async throws -> CardiacHealthProfile {
         logger.info("Generating cardiac health profile for \(windowDays) days")
         
-        let endDate = Date()
-        let startDate = Calendar.current.date(byAdding: .day, value: -windowDays, to: endDate) ?? endDate
-        
         // Gather cardiac metrics concurrently
         async let restingHR = fetchLatestMetric(.restingHeartRate, days: windowDays)
         async let hrv = fetchLatestMetric(.heartRateVariability, days: windowDays)
@@ -156,7 +153,7 @@ public final class CardiacAnalytics {
         
         let overallScore = calculateOverallCardiacScore(metrics: metrics)
         let riskLevel = determineRiskLevel(score: overallScore, metrics: metrics)
-        let insights = generateInsights(metrics: metrics, windowDays: windowDays)
+        let insights = generateInsights(metrics: metrics)
         let recommendations = generateRecommendations(metrics: metrics, riskLevel: riskLevel)
         
         return CardiacHealthProfile(
@@ -352,7 +349,7 @@ public final class CardiacAnalytics {
         return .veryHigh
     }
     
-    private func generateInsights(metrics: CardiacMetrics, windowDays: Int) -> [Insight] {
+    private func generateInsights(metrics: CardiacMetrics) -> [Insight] {
         var insights: [Insight] = []
         
         // HRV Insights

--- a/S2Y/LLM/EnhancedHealthChatController.swift
+++ b/S2Y/LLM/EnhancedHealthChatController.swift
@@ -262,7 +262,7 @@ public final class EnhancedHealthChatController: ObservableObject {
         let fallbackContent: String
         let structuredData: EnhancedStructuredData?
         
-        if let lastAnalysis = healthIntelligence.lastAnalysis {
+        if healthIntelligence.lastAnalysis != nil {
             fallbackContent = """
             I'm having trouble connecting to my AI service, but I can still help with your health data locally.
             

--- a/S2Y/Onboarding/NotificationPermissions.swift
+++ b/S2Y/Onboarding/NotificationPermissions.swift
@@ -49,12 +49,9 @@ struct NotificationPermissions: View {
                             if ProcessInfo.processInfo.isPreviewSimulator {
                                 try await _Concurrency.Task.sleep(for: .seconds(5))
                             } else {
-                                var opts: UNAuthorizationOptions = [.alert, .sound, .badge]
-                                if !UserDefaults.standard.bool(forKey: StorageKeys.disableTimeSensitiveNotifications) {
-                                    if #available(iOS 15.0, *) {
-                                        opts.insert(.timeSensitive)
-                                    }
-                                }
+                                // Time-sensitive delivery is controlled by the app entitlement and
+                                // each notification's interruption level, not an authorization option.
+                                let opts: UNAuthorizationOptions = [.alert, .sound, .badge]
                                 _ = try await requestNotificationAuthorization(options: opts)
                             }
                         } catch {

--- a/S2Y/SharedContext/StorageKeys.swift
+++ b/S2Y/SharedContext/StorageKeys.swift
@@ -20,8 +20,6 @@ enum StorageKeys {
     static let tabViewCustomization = "home.tab-view-customization"
 
     // MARK: - Debug Toggles (Runtime)
-    /// Disable Time Sensitive Notifications usage at runtime
-    static let disableTimeSensitiveNotifications = "debug.disable-time-sensitive-notifications"
     /// Disable Scheduler module configuration and UI at runtime
     static let disableScheduler = "debug.disable-scheduler"
     /// Disable Bluetooth features at runtime


### PR DESCRIPTION
## User stories
- HLT-061 requests only supported notification authorization options
- HLT-062 uses the current microphone permission and Bluetooth HFP APIs
- HLT-063 adopts the current SwiftUI change observer and removes an unused binding
- HLT-064 keeps cardiac analysis windows tied directly to HealthKit metric queries

## Validation
- iOS Simulator app build (iPhone 17, arm64)
- full S2Y unit test suite (UI tests excluded)
- git diff --check

## Result
The notification, speech, assistant observation, and cardiac window warnings targeted by this epic no longer appear in the build.