### PR TITLE
EPIC-H20: validate HealthKit tool requests

### DIFF
--- a/Docs/health-query-tool-schema.md
+++ b/Docs/health-query-tool-schema.md
@@ -1,0 +1,18 @@
+# Health query tool schema
+
+Health Assistant uses a versioned, closed request schema before reading HealthKit trend or comparison data.
+
+```json
+{
+  "version": 1,
+  "operation": "trend | compare_periods",
+  "metric": "HealthKit MetricKind raw value",
+  "windowDays": "integer from 1 through 90"
+}
+```
+
+Validation happens locally before HealthKit is queried or an AI provider is contacted. Unknown operations fail JSON decoding. Unknown metrics, unsupported schema versions, zero-length windows, and windows above 90 days fail validation.
+
+Natural-language parsing, chat chart selection, and AI health context use the same validated request. An invalid structured request returns a corrective message instead of silently changing its metric, operation, or time window. A query that does not describe a supported structured tool remains ordinary conversation.
+
+HealthKit authorization and data-availability failures are not retried automatically: retrying cannot grant permission and must not obscure missing data. Read caching handles repeated valid requests.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The [DocC documentation of the Spezi Template Application contains information o
 - Roadmap: [Docs/roadmap.md](Docs/roadmap.md)
 - Health Assistant Epics: [Docs/epics.md](Docs/epics.md)
 - AI Provider Boundaries: [Docs/ai-provider-architecture.md](Docs/ai-provider-architecture.md)
+- Health Query Tool Schema: [Docs/health-query-tool-schema.md](Docs/health-query-tool-schema.md)
 - TODO: [Docs/todo.md](Docs/todo.md)
 
 ## Contributing

--- a/S2Y/HealthAssistant/HealthChatVisualization.swift
+++ b/S2Y/HealthAssistant/HealthChatVisualization.swift
@@ -16,11 +16,11 @@ enum HealthChartRequest: Equatable, Sendable {
         guard let intent = QueryPlanner.parse(query) else {
             return nil
         }
-        switch intent {
-        case .trend(let kind, let days):
-            return .trend(kind: kind, days: days)
-        case .compare(let kind, let windowDays):
-            return .comparison(kind: kind, days: windowDays)
+        switch intent.operation {
+        case .trend:
+            return .trend(kind: intent.metric, days: intent.windowDays)
+        case .comparePeriods:
+            return .comparison(kind: intent.metric, days: intent.windowDays)
         }
     }
 }

--- a/S2Y/HealthAssistant/HealthQueryProcessor.swift
+++ b/S2Y/HealthAssistant/HealthQueryProcessor.swift
@@ -33,8 +33,13 @@ enum HealthQueryProcessor {
     
     static func processQuery(_ query: String) async throws -> QueryResult {
         // Structured HealthKit operations always use the validated tool contract.
-        if let intent = QueryPlanner.parse(query) {
+        switch QueryPlanner.parseResult(query) {
+        case .valid(let intent):
             return try await processStructuredQuery(intent)
+        case .invalid(let error):
+            return .textResponse(error.localizedDescription)
+        case .noMatch:
+            break
         }
 
         // Broader summaries and guidance use the enhanced planner.

--- a/S2Y/HealthAssistant/HealthQueryProcessor.swift
+++ b/S2Y/HealthAssistant/HealthQueryProcessor.swift
@@ -32,14 +32,14 @@ enum HealthQueryProcessor {
     }
     
     static func processQuery(_ query: String) async throws -> QueryResult {
-        // Use enhanced query planner for better processing
-        if let intent = EnhancedQueryPlanner.parse(query) {
-            return try await EnhancedQueryPlanner.run(intent: intent)
-        }
-        
-        // Fall back to basic query processing
+        // Structured HealthKit operations always use the validated tool contract.
         if let intent = QueryPlanner.parse(query) {
             return try await processStructuredQuery(intent)
+        }
+
+        // Broader summaries and guidance use the enhanced planner.
+        if let intent = EnhancedQueryPlanner.parse(query) {
+            return try await EnhancedQueryPlanner.run(intent: intent)
         }
         
         // Check for insight-related queries
@@ -52,14 +52,22 @@ enum HealthQueryProcessor {
     }
     
     private static func processStructuredQuery(_ intent: QueryPlanner.Intent) async throws -> QueryResult {
-        switch intent {
-        case let .trend(kind, days):
-            let trend = try await HealthKitService.shared.trend(kind: kind, days: days, useCache: true)
-            return .trend(trend, kind)
+        switch intent.operation {
+        case .trend:
+            let trend = try await HealthKitService.shared.trend(
+                kind: intent.metric,
+                days: intent.windowDays,
+                useCache: true
+            )
+            return .trend(trend, intent.metric)
             
-        case let .compare(kind, windowDays):
-            let comparison = try await HealthKitService.shared.compare(kind: kind, windowDays: windowDays, useCache: true)
-            return .comparison(comparison, kind)
+        case .comparePeriods:
+            let comparison = try await HealthKitService.shared.compare(
+                kind: intent.metric,
+                windowDays: intent.windowDays,
+                useCache: true
+            )
+            return .comparison(comparison, intent.metric)
         }
     }
     

--- a/S2Y/HealthAssistant/HealthQueryToolRequest.swift
+++ b/S2Y/HealthAssistant/HealthQueryToolRequest.swift
@@ -1,0 +1,38 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 S2Y Health
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+struct HealthQueryToolRequest: Codable, Equatable, Sendable {
+    static let schemaVersion = 1
+
+    enum Operation: String, Codable, CaseIterable, Sendable {
+        case trend
+        case comparePeriods = "compare_periods"
+    }
+
+    let version: Int
+    let operation: Operation
+    let metric: String
+    let windowDays: Int
+
+    init(
+        version: Int = schemaVersion,
+        operation: Operation,
+        metric: HealthKitService.MetricKind,
+        windowDays: Int
+    ) {
+        self.version = version
+        self.operation = operation
+        self.metric = metric.rawValue
+        self.windowDays = windowDays
+    }
+
+    var metricKind: HealthKitService.MetricKind? {
+        HealthKitService.MetricKind(rawValue: metric)
+    }
+}

--- a/S2Y/HealthAssistant/HealthQueryToolRequest.swift
+++ b/S2Y/HealthAssistant/HealthQueryToolRequest.swift
@@ -35,4 +35,46 @@ struct HealthQueryToolRequest: Codable, Equatable, Sendable {
     var metricKind: HealthKitService.MetricKind? {
         HealthKitService.MetricKind(rawValue: metric)
     }
+
+    func validated() throws -> ValidatedHealthQueryToolRequest {
+        guard version == Self.schemaVersion else {
+            throw HealthQueryToolRequestError.unsupportedVersion(version)
+        }
+        guard let metricKind else {
+            throw HealthQueryToolRequestError.unknownMetric(metric)
+        }
+        guard Self.allowedWindowDays.contains(windowDays) else {
+            throw HealthQueryToolRequestError.windowOutOfRange(windowDays)
+        }
+        return ValidatedHealthQueryToolRequest(
+            operation: operation,
+            metric: metricKind,
+            windowDays: windowDays
+        )
+    }
+
+    private static let allowedWindowDays = 1...90
+}
+
+struct ValidatedHealthQueryToolRequest: Equatable, Sendable {
+    let operation: HealthQueryToolRequest.Operation
+    let metric: HealthKitService.MetricKind
+    let windowDays: Int
+}
+
+enum HealthQueryToolRequestError: LocalizedError, Equatable, Sendable {
+    case unsupportedVersion(Int)
+    case unknownMetric(String)
+    case windowOutOfRange(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedVersion(let version):
+            "Unsupported health tool schema version: \(version)."
+        case .unknownMetric:
+            "That health metric is not supported."
+        case .windowOutOfRange:
+            "Choose a time window from 1 to 90 days."
+        }
+    }
 }

--- a/S2Y/LLM/QueryPlanner.swift
+++ b/S2Y/LLM/QueryPlanner.swift
@@ -9,10 +9,7 @@
 import Foundation
 
 enum QueryPlanner {
-    enum Intent {
-        case compare(kind: HealthKitService.MetricKind, windowDays: Int)
-        case trend(kind: HealthKitService.MetricKind, days: Int)
-    }
+    typealias Intent = ValidatedHealthQueryToolRequest
 
     static func parse(_ text: String) -> Intent? {
         let lowered = text.lowercased()
@@ -42,8 +39,10 @@ enum QueryPlanner {
 
         guard let kind = metric else { return nil }
 
-        // window/days detection
         let days: Int = {
+            if let explicitDays = extractExplicitDays(from: lowered) {
+                return explicitDays
+            }
             if lowered.contains("30天") || lowered.contains("30-day") || lowered.contains("30 days") {
                 return 30
             }
@@ -56,40 +55,64 @@ enum QueryPlanner {
         // intent detection
         let isCompare = lowered.contains("对比") || lowered.contains("compare") || lowered.contains("vs")
         if isCompare {
-            return .compare(kind: kind, windowDays: days)
+            return validatedRequest(operation: .comparePeriods, metric: kind, windowDays: days)
         }
 
         let isTrend = lowered.contains("趋势") || lowered.contains("trend") || lowered.contains("变化")
         if isTrend {
-            return .trend(kind: kind, days: days)
+            return validatedRequest(operation: .trend, metric: kind, windowDays: days)
         }
 
         // default to compare for common phrasing like "过去7天 ... vs 上周"
         if lowered.contains("上周") || lowered.contains("last week") {
-            return .compare(kind: kind, windowDays: days)
+            return validatedRequest(operation: .comparePeriods, metric: kind, windowDays: days)
         }
 
         return nil
     }
 
     static func run(intent: Intent) async throws -> String {
-        switch intent {
-        case let .compare(kind, windowDays):
+        switch intent.operation {
+        case .comparePeriods:
             let comparison = try await HealthKitService.shared.compare(
-                kind: kind,
-                windowDays: windowDays,
+                kind: intent.metric,
+                windowDays: intent.windowDays,
                 useCache: true
             )
-            return formatComparison(kind: kind, comparison: comparison)
+            return formatComparison(kind: intent.metric, comparison: comparison)
 
-        case let .trend(kind, days):
+        case .trend:
             let trendResult = try await HealthKitService.shared.trend(
-                kind: kind,
-                days: days,
+                kind: intent.metric,
+                days: intent.windowDays,
                 useCache: true
             )
-            return formatTrend(kind: kind, trend: trendResult)
+            return formatTrend(kind: intent.metric, trend: trendResult)
         }
+    }
+
+    private static func validatedRequest(
+        operation: HealthQueryToolRequest.Operation,
+        metric: HealthKitService.MetricKind,
+        windowDays: Int
+    ) -> Intent? {
+        try? HealthQueryToolRequest(
+            operation: operation,
+            metric: metric,
+            windowDays: windowDays
+        ).validated()
+    }
+
+    private static func extractExplicitDays(from text: String) -> Int? {
+        guard let expression = try? NSRegularExpression(pattern: #"(\d{1,4})\s*(?:days?|天)"#),
+              let match = expression.firstMatch(
+                in: text,
+                range: NSRange(text.startIndex..., in: text)
+              ),
+              let range = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+        return Int(text[range])
     }
 
     private static func metricUnit(kind: HealthKitService.MetricKind) -> String {
@@ -127,4 +150,3 @@ enum QueryPlanner {
         return "\(title)\n窗口平均：\(String(format: "%.2f", avg)) \(unit)\n首末变化：\(arrow) \(String(format: "%.1f", abs(rate)))%\n建议：保持良好习惯，必要时逐步调整计划。"
     }
 }
-

--- a/S2Y/LLM/QueryPlanner.swift
+++ b/S2Y/LLM/QueryPlanner.swift
@@ -11,33 +11,20 @@ import Foundation
 enum QueryPlanner {
     typealias Intent = ValidatedHealthQueryToolRequest
 
+    enum ParseResult: Equatable {
+        case noMatch
+        case valid(Intent)
+        case invalid(HealthQueryToolRequestError)
+    }
+
     static func parse(_ text: String) -> Intent? {
+        guard case .valid(let intent) = parseResult(text) else { return nil }
+        return intent
+    }
+
+    static func parseResult(_ text: String) -> ParseResult {
         let lowered = text.lowercased()
-
-        // metric detection
-        let metric: HealthKitService.MetricKind? = {
-            if lowered.contains("步数") || lowered.contains("steps") {
-                return .steps
-            }
-            if lowered.contains("静息心率") || lowered.contains("resting heart") {
-                return .restingHeartRate
-            }
-            if lowered.contains("心率") || lowered.contains("heart rate") {
-                return .heartRateAverage
-            }
-            if lowered.contains("活动能量") || lowered.contains("active energy") || lowered.contains("calorie") {
-                return .activeEnergy
-            }
-            if lowered.contains("体重") || lowered.contains("body mass") || lowered.contains("weight") {
-                return .bodyMass
-            }
-            if lowered.contains("睡眠") || lowered.contains("sleep") {
-                return .sleepDurationHours
-            }
-            return nil
-        }()
-
-        guard let kind = metric else { return nil }
+        guard let kind = detectMetric(in: lowered) else { return .noMatch }
 
         let days: Int = {
             if let explicitDays = extractExplicitDays(from: lowered) {
@@ -52,23 +39,30 @@ enum QueryPlanner {
             return 7
         }()
 
-        // intent detection
+        let operation: HealthQueryToolRequest.Operation
         let isCompare = lowered.contains("对比") || lowered.contains("compare") || lowered.contains("vs")
         if isCompare {
-            return validatedRequest(operation: .comparePeriods, metric: kind, windowDays: days)
+            operation = .comparePeriods
+        } else if lowered.contains("趋势") || lowered.contains("trend") || lowered.contains("变化") {
+            operation = .trend
+        } else if lowered.contains("上周") || lowered.contains("last week") {
+            operation = .comparePeriods
+        } else {
+            return .noMatch
         }
 
-        let isTrend = lowered.contains("趋势") || lowered.contains("trend") || lowered.contains("变化")
-        if isTrend {
-            return validatedRequest(operation: .trend, metric: kind, windowDays: days)
+        let request = HealthQueryToolRequest(
+            operation: operation,
+            metric: kind,
+            windowDays: days
+        )
+        do {
+            return .valid(try request.validated())
+        } catch let error as HealthQueryToolRequestError {
+            return .invalid(error)
+        } catch {
+            return .noMatch
         }
-
-        // default to compare for common phrasing like "过去7天 ... vs 上周"
-        if lowered.contains("上周") || lowered.contains("last week") {
-            return validatedRequest(operation: .comparePeriods, metric: kind, windowDays: days)
-        }
-
-        return nil
     }
 
     static func run(intent: Intent) async throws -> String {
@@ -91,16 +85,16 @@ enum QueryPlanner {
         }
     }
 
-    private static func validatedRequest(
-        operation: HealthQueryToolRequest.Operation,
-        metric: HealthKitService.MetricKind,
-        windowDays: Int
-    ) -> Intent? {
-        try? HealthQueryToolRequest(
-            operation: operation,
-            metric: metric,
-            windowDays: windowDays
-        ).validated()
+    private static func detectMetric(in text: String) -> HealthKitService.MetricKind? {
+        if text.contains("步数") || text.contains("step") { return .steps }
+        if text.contains("静息心率") || text.contains("resting heart") { return .restingHeartRate }
+        if text.contains("心率") || text.contains("heart rate") { return .heartRateAverage }
+        if text.contains("活动能量") || text.contains("active energy") || text.contains("calorie") {
+            return .activeEnergy
+        }
+        if text.contains("体重") || text.contains("body mass") || text.contains("weight") { return .bodyMass }
+        if text.contains("睡眠") || text.contains("sleep") { return .sleepDurationHours }
+        return nil
     }
 
     private static func extractExplicitDays(from text: String) -> Int? {

--- a/S2YTests/HealthQueryToolRequestTests.swift
+++ b/S2YTests/HealthQueryToolRequestTests.swift
@@ -1,0 +1,33 @@
+//
+// This source file is part of the S2Y application project
+//
+// SPDX-FileCopyrightText: 2026 S2Y Health
+//
+// SPDX-License-Identifier: MIT
+
+import XCTest
+@testable import S2Y
+
+final class HealthQueryToolRequestTests: XCTestCase {
+    func testToolRequestRoundTripsAsStableJSONSchema() throws {
+        let request = HealthQueryToolRequest(
+            operation: .comparePeriods,
+            metric: .sleepDurationHours,
+            windowDays: 7
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["version"] as? Int, 1)
+        XCTAssertEqual(object["operation"] as? String, "compare_periods")
+        XCTAssertEqual(object["metric"] as? String, "sleepDurationHours")
+        XCTAssertEqual(object["windowDays"] as? Int, 7)
+        XCTAssertEqual(try JSONDecoder().decode(HealthQueryToolRequest.self, from: data), request)
+        XCTAssertEqual(request.metricKind, .sleepDurationHours)
+    }
+
+    func testToolOperationsRemainExplicitAndFinite() {
+        XCTAssertEqual(HealthQueryToolRequest.Operation.allCases, [.trend, .comparePeriods])
+    }
+}

--- a/S2YTests/HealthQueryToolRequestTests.swift
+++ b/S2YTests/HealthQueryToolRequestTests.swift
@@ -30,4 +30,54 @@ final class HealthQueryToolRequestTests: XCTestCase {
     func testToolOperationsRemainExplicitAndFinite() {
         XCTAssertEqual(HealthQueryToolRequest.Operation.allCases, [.trend, .comparePeriods])
     }
+
+    func testValidationResolvesKnownMetric() throws {
+        let request = HealthQueryToolRequest(
+            operation: .trend,
+            metric: .heartRateAverage,
+            windowDays: 30
+        )
+
+        XCTAssertEqual(
+            try request.validated(),
+            ValidatedHealthQueryToolRequest(
+                operation: .trend,
+                metric: .heartRateAverage,
+                windowDays: 30
+            )
+        )
+    }
+
+    func testValidationRejectsUnknownMetricFromDecodedPayload() throws {
+        let data = try XCTUnwrap(
+            #"{"version":1,"operation":"trend","metric":"readinessScore","windowDays":7}"#
+                .data(using: .utf8)
+        )
+        let request = try JSONDecoder().decode(HealthQueryToolRequest.self, from: data)
+
+        XCTAssertThrowsError(try request.validated()) { error in
+            XCTAssertEqual(error as? HealthQueryToolRequestError, .unknownMetric("readinessScore"))
+        }
+    }
+
+    func testValidationRejectsUnsupportedVersionAndUnsafeWindows() throws {
+        let futureVersion = HealthQueryToolRequest(
+            version: 2,
+            operation: .trend,
+            metric: .steps,
+            windowDays: 7
+        )
+        let oversized = HealthQueryToolRequest(
+            operation: .trend,
+            metric: .steps,
+            windowDays: 365
+        )
+
+        XCTAssertThrowsError(try futureVersion.validated()) { error in
+            XCTAssertEqual(error as? HealthQueryToolRequestError, .unsupportedVersion(2))
+        }
+        XCTAssertThrowsError(try oversized.validated()) { error in
+            XCTAssertEqual(error as? HealthQueryToolRequestError, .windowOutOfRange(365))
+        }
+    }
 }

--- a/S2YTests/HealthQueryToolRequestTests.swift
+++ b/S2YTests/HealthQueryToolRequestTests.swift
@@ -98,4 +98,30 @@ final class HealthQueryToolRequestTests: XCTestCase {
         )
         XCTAssertNil(HealthChartRequest.parse("Show my step trend for 365 days"))
     }
+
+    func testParserClassifiesUnsafeWindowInsteadOfSilentlyDefaulting() {
+        XCTAssertEqual(
+            QueryPlanner.parseResult("Show my step trend for 365 days"),
+            .invalid(.windowOutOfRange(365))
+        )
+        XCTAssertEqual(QueryPlanner.parseResult("Tell me a joke"), .noMatch)
+    }
+
+    func testProcessorReturnsSafeValidationMessageWithoutExecutingHealthKit() async throws {
+        let result = try await HealthQueryProcessor.processQuery("Show my sleep trend for 365 days")
+
+        guard case .textResponse(let message) = result else {
+            return XCTFail("Expected a validation response")
+        }
+        XCTAssertEqual(message, "Choose a time window from 1 to 90 days.")
+    }
+
+    func testMalformedToolOperationFailsClosedDuringDecoding() throws {
+        let data = try XCTUnwrap(
+            #"{"version":1,"operation":"diagnose","metric":"steps","windowDays":7}"#
+                .data(using: .utf8)
+        )
+
+        XCTAssertThrowsError(try JSONDecoder().decode(HealthQueryToolRequest.self, from: data))
+    }
 }

--- a/S2YTests/HealthQueryToolRequestTests.swift
+++ b/S2YTests/HealthQueryToolRequestTests.swift
@@ -80,4 +80,22 @@ final class HealthQueryToolRequestTests: XCTestCase {
             XCTAssertEqual(error as? HealthQueryToolRequestError, .windowOutOfRange(365))
         }
     }
+
+    func testNaturalLanguagePlannerProducesValidatedToolRequest() throws {
+        let intent = try XCTUnwrap(
+            QueryPlanner.parse("Compare my sleep over 30 days vs the previous period")
+        )
+
+        XCTAssertEqual(intent.operation, .comparePeriods)
+        XCTAssertEqual(intent.metric, .sleepDurationHours)
+        XCTAssertEqual(intent.windowDays, 30)
+    }
+
+    func testChartRequestUsesSameValidatedContract() {
+        XCTAssertEqual(
+            HealthChartRequest.parse("Show my step trend for 14 days"),
+            .trend(kind: .steps, days: 14)
+        )
+        XCTAssertNil(HealthChartRequest.parse("Show my step trend for 365 days"))
+    }
 }


### PR DESCRIPTION
## User stories
- HLT-079 defines a stable, versioned Codable schema for HealthKit trend and period-comparison tools
- HLT-080 validates schema version, metric identity, operation, and 1–90 day windows
- HLT-081 makes natural-language parsing, chat charts, and AI health context use the same validated request
- HLT-082 classifies invalid structured requests and fails closed with corrective guidance

## Schema
`{ version, operation: trend | compare_periods, metric, windowDays }`

## Safety behavior
- Unknown operations fail decoding
- Unknown metrics and unsupported schema versions fail validation
- Zero, negative, and >90-day windows are rejected
- “365-day step trend” is never silently executed as a 7-day query
- HealthKit permission/data availability failures are not blindly retried
- Non-tool conversation remains ordinary AI chat

## Validation
- iPhone 17 Simulator app build
- 10 focused HealthQueryToolRequestTests
- full S2Y unit test suite (UI tests excluded)
- git diff --check

## Documentation
Adds `Docs/health-query-tool-schema.md` and links it from README.