### PR TITLE
H23: Require user-selected wellbeing goals

### DIFF
--- a/S2Y/HealthKit/HealthKitService.swift
+++ b/S2Y/HealthKit/HealthKitService.swift
@@ -330,7 +330,6 @@ public final class HealthKitService {
             HealthMetricsDictionary.formatValue(value, for: self)
         }
         
-        /// Get health assessment for a value
     }
 
     // Explicit aggregation control for generic quantity metrics

--- a/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
@@ -208,7 +208,16 @@ struct WellnessPlanSettingsView: View {
                     Text(action.detail).font(.caption).foregroundStyle(.secondary)
                     Text("\(action.daysPerWeek) days/week · about \(action.estimatedMinutes) min")
                         .font(.caption2).foregroundStyle(.tertiary)
+                    if plan.status == .draft {
+                        Button(action.confirmedAt == nil ? "Include this action" : "Included") {
+                            toggleActionConfirmation(action, in: plan)
+                        }
+                        .font(.caption)
+                    }
                 }
+            }
+            .onDelete { offsets in
+                removeActions(at: offsets, from: plan)
             }
             if plan.status == .draft {
                 Button("Review complete — activate plan") {
@@ -218,6 +227,8 @@ struct WellnessPlanSettingsView: View {
                         errorMessage = "Review and confirm every personal goal before activation."
                     } catch WellnessPlanTransitionError.invalidGoal {
                         errorMessage = "A goal has an invalid value, unit, or review date. Edit it before activation."
+                    } catch WellnessPlanTransitionError.unconfirmedAction {
+                        errorMessage = "Choose which suggested actions to include before activation."
                     } catch {
                         errorMessage = "Add at least one personal goal and keep at least one optional action before activation."
                     }
@@ -373,6 +384,25 @@ struct WellnessPlanSettingsView: View {
         var updated = plan
         updated.goals = updated.goals.enumerated().compactMap { index, goal in
             offsets.contains(index) ? nil : goal
+        }
+        updated.updatedAt = .now
+        planStore.save(updated)
+    }
+
+    private func toggleActionConfirmation(_ action: WellnessAction, in plan: WellnessPlan) {
+        guard plan.status == .draft,
+              let index = plan.actions.firstIndex(where: { $0.id == action.id }) else { return }
+        var updated = plan
+        updated.actions[index].confirmedAt = action.confirmedAt == nil ? .now : nil
+        updated.updatedAt = .now
+        planStore.save(updated)
+    }
+
+    private func removeActions(at offsets: IndexSet, from plan: WellnessPlan) {
+        guard plan.status == .draft else { return }
+        var updated = plan
+        updated.actions = updated.actions.enumerated().compactMap { index, action in
+            offsets.contains(index) ? nil : action
         }
         updated.updatedAt = .now
         planStore.save(updated)

--- a/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDailyActions.swift
@@ -111,6 +111,11 @@ struct WellnessPlanSettingsView: View {
     @StateObject private var planStore = WellnessPlanStore.shared
     @StateObject private var recordStore = WellnessActionRecordStore.shared
     @State private var isCreatingDraft = false
+    @State private var isAddingGoal = false
+    @State private var goalMetric: HealthKitService.MetricKind = .steps
+    @State private var goalDirection: WellnessGoal.Direction = .consistency
+    @State private var goalTargetText = ""
+    @State private var goalReviewDate = Calendar.current.date(byAdding: .day, value: 14, to: .now) ?? .now
     @State private var errorMessage: String?
 
     var body: some View {
@@ -159,6 +164,9 @@ struct WellnessPlanSettingsView: View {
         } message: {
             Text(errorMessage ?? "")
         }
+        .sheet(isPresented: $isAddingGoal) {
+            goalEditor
+        }
     }
 
     @ViewBuilder
@@ -168,6 +176,31 @@ struct WellnessPlanSettingsView: View {
                 Text(plan.title).font(.headline)
                 Text(plan.summary).font(.caption).foregroundStyle(.secondary)
                 LabeledContent("Status", value: plan.status.rawValue.capitalized)
+            }
+            if plan.goals.isEmpty {
+                Text("No personal goal selected yet.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(plan.goals) { goal in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(goal.metricKind.displayName)
+                            .font(.subheadline.weight(.semibold))
+                        Text(goalDescription(goal))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onDelete { offsets in
+                    removeGoals(at: offsets, from: plan)
+                }
+            }
+            if plan.status == .draft {
+                Button {
+                    prepareGoalEditor()
+                } label: {
+                    Label("Add my goal", systemImage: "plus.circle")
+                }
             }
             ForEach(plan.actions) { action in
                 VStack(alignment: .leading, spacing: 3) {
@@ -181,8 +214,12 @@ struct WellnessPlanSettingsView: View {
                 Button("Review complete — activate plan") {
                     do {
                         planStore.save(try WellnessPlanLifecycle.transition(plan, to: .active))
+                    } catch WellnessPlanTransitionError.unconfirmedGoal {
+                        errorMessage = "Review and confirm every personal goal before activation."
+                    } catch WellnessPlanTransitionError.invalidGoal {
+                        errorMessage = "A goal has an invalid value, unit, or review date. Edit it before activation."
                     } catch {
-                        errorMessage = "This draft needs at least one personal goal and one action before activation."
+                        errorMessage = "Add at least one personal goal and keep at least one optional action before activation."
                     }
                 }
             } else if plan.status == .active {
@@ -251,5 +288,107 @@ struct WellnessPlanSettingsView: View {
             return
         }
         planStore.save(WellnessPlanDraftBuilder.build(from: report).plan)
+    }
+
+    private var goalEditor: some View {
+        NavigationStack {
+            Form {
+                Picker("Metric", selection: $goalMetric) {
+                    ForEach(HealthKitService.MetricKind.allCases, id: \.self) { metric in
+                        Text(metric.displayName).tag(metric)
+                    }
+                }
+                Picker("Direction", selection: $goalDirection) {
+                    ForEach(WellnessGoal.Direction.allCases, id: \.self) { direction in
+                        Text(directionLabel(direction)).tag(direction)
+                    }
+                }
+                TextField("Optional numeric target", text: $goalTargetText)
+                    .keyboardType(.decimalPad)
+                Text("Unit: \(goalMetric.unit)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                DatePicker(
+                    "Review date",
+                    selection: $goalReviewDate,
+                    in: Date.now...,
+                    displayedComponents: .date
+                )
+                Section {
+                    Text("This is the target you chose. S2Y records progress but does not assess whether the target is medically appropriate.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("My Goal")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { isAddingGoal = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") { addGoal() }
+                        .disabled(!isGoalTargetValid)
+                }
+            }
+        }
+    }
+
+    private var parsedGoalTarget: Double? {
+        let trimmed = goalTargetText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return Double(trimmed)
+    }
+
+    private var isGoalTargetValid: Bool {
+        let trimmed = goalTargetText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty || parsedGoalTarget.map { $0.isFinite && $0 > 0 } == true
+    }
+
+    private func prepareGoalEditor() {
+        goalMetric = .steps
+        goalDirection = .consistency
+        goalTargetText = ""
+        goalReviewDate = Calendar.current.date(byAdding: .day, value: 14, to: .now) ?? .now
+        isAddingGoal = true
+    }
+
+    private func addGoal() {
+        guard var plan = planStore.currentPlan, plan.status == .draft, isGoalTargetValid else { return }
+        let goal = WellnessGoal.userSelected(
+            metricKind: goalMetric,
+            direction: goalDirection,
+            targetValue: parsedGoalTarget,
+            reviewDate: goalReviewDate
+        )
+        plan.goals.removeAll { $0.metricKind == goalMetric }
+        plan.goals.append(goal)
+        plan.updatedAt = .now
+        planStore.save(plan)
+        isAddingGoal = false
+    }
+
+    private func removeGoals(at offsets: IndexSet, from plan: WellnessPlan) {
+        guard plan.status == .draft else { return }
+        var updated = plan
+        updated.goals = updated.goals.enumerated().compactMap { index, goal in
+            offsets.contains(index) ? nil : goal
+        }
+        updated.updatedAt = .now
+        planStore.save(updated)
+    }
+
+    private func goalDescription(_ goal: WellnessGoal) -> String {
+        let target = goal.targetValue.map { goal.metricKind.formatValue($0) } ?? "no numeric target"
+        return "\(directionLabel(goal.direction)) · \(target) · review \(goal.reviewDate.formatted(date: .abbreviated, time: .omitted))"
+    }
+
+    private func directionLabel(_ direction: WellnessGoal.Direction) -> String {
+        switch direction {
+        case .increase: "Increase"
+        case .decrease: "Decrease"
+        case .maintain: "Maintain"
+        case .consistency: "Consistency"
+        }
     }
 }

--- a/S2Y/WellnessPlan/WellnessPlanDraftBuilder.swift
+++ b/S2Y/WellnessPlan/WellnessPlanDraftBuilder.swift
@@ -17,25 +17,14 @@ struct WellnessPlanDraft: Sendable, Equatable {
 enum WellnessPlanDraftBuilder {
     static func build(
         from report: PersonalHealthInsightReport,
-        now: Date = .now,
-        calendar: Calendar = .current
+        now: Date = .now
     ) -> WellnessPlanDraft {
-        let reviewDate = calendar.date(byAdding: .day, value: 14, to: now) ?? now
-        var goals: [WellnessGoal] = []
         var actions: [WellnessAction] = []
         var rationale: [String] = []
 
         for deviation in report.deviations where deviation.direction != .undetermined {
-            guard let currentMedian = deviation.currentMedian else { continue }
             switch deviation.metricKind {
             case .sleepDurationHours:
-                goals.append(WellnessGoal(
-                    metricKind: .sleepDurationHours,
-                    direction: .consistency,
-                    targetValue: currentMedian,
-                    targetUnit: deviation.metricKind.unit,
-                    reviewDate: reviewDate
-                ))
                 actions.append(WellnessAction(
                     title: "Keep a consistent wind-down window",
                     detail: "Choose a realistic bedtime routine and adjust it whenever it no longer fits.",
@@ -45,13 +34,6 @@ enum WellnessPlanDraftBuilder {
                 ))
                 rationale.append("Recent sleep was compared with your own earlier baseline using \(deviation.currentObservedDays) recent and \(deviation.baselineObservedDays) baseline days.")
             case .steps, .activeEnergy:
-                goals.append(WellnessGoal(
-                    metricKind: deviation.metricKind,
-                    direction: deviation.direction == .lower ? .increase : .maintain,
-                    targetValue: currentMedian,
-                    targetUnit: deviation.metricKind.unit,
-                    reviewDate: reviewDate
-                ))
                 actions.append(WellnessAction(
                     title: "Choose a comfortable movement break",
                     detail: "Try a short walk or another comfortable activity. Stop or adjust if it does not feel right.",
@@ -61,13 +43,6 @@ enum WellnessPlanDraftBuilder {
                 ))
                 rationale.append("Recent \(deviation.metricKind.displayName.lowercased()) was compared with your own earlier baseline, not a population target.")
             case .restingHeartRate, .heartRateAverage, .heartRateVariability:
-                goals.append(WellnessGoal(
-                    metricKind: deviation.metricKind,
-                    direction: .consistency,
-                    targetValue: nil,
-                    targetUnit: deviation.metricKind.unit,
-                    reviewDate: reviewDate
-                ))
                 actions.append(WellnessAction(
                     title: "Add a quiet recovery check-in",
                     detail: "Pause for slow breathing or a brief reflection. This is for general wellbeing, not treatment.",
@@ -98,7 +73,7 @@ enum WellnessPlanDraftBuilder {
             summary: "A flexible health-management draft based on your observed data. Review and edit it before activation.",
             status: .draft,
             origin: .assistantDraft,
-            goals: goals,
+            goals: [],
             actions: deduplicate(actions),
             createdAt: now,
             updatedAt: now
@@ -109,6 +84,7 @@ enum WellnessPlanDraftBuilder {
             limitations: [
                 "This draft is for general wellbeing and health management, not diagnosis or treatment.",
                 "Associations in your data do not show that one behavior caused another outcome.",
+                "S2Y does not choose a personal target. Add and confirm your own goal before activation.",
                 "Nothing is scheduled or activated until you confirm the draft."
             ]
         )

--- a/S2Y/WellnessPlan/WellnessPlanModels.swift
+++ b/S2Y/WellnessPlan/WellnessPlanModels.swift
@@ -22,6 +22,7 @@ public struct WellnessGoal: Codable, Identifiable, Sendable, Equatable {
     public var targetValue: Double?
     public var targetUnit: String
     public var reviewDate: Date
+    public var confirmedAt: Date?
 
     public init(
         id: UUID = UUID(),
@@ -29,7 +30,8 @@ public struct WellnessGoal: Codable, Identifiable, Sendable, Equatable {
         direction: Direction,
         targetValue: Double?,
         targetUnit: String,
-        reviewDate: Date
+        reviewDate: Date,
+        confirmedAt: Date? = nil
     ) {
         self.id = id
         self.metricKind = metricKind
@@ -37,6 +39,24 @@ public struct WellnessGoal: Codable, Identifiable, Sendable, Equatable {
         self.targetValue = targetValue
         self.targetUnit = targetUnit
         self.reviewDate = reviewDate
+        self.confirmedAt = confirmedAt
+    }
+
+    public static func userSelected(
+        metricKind: HealthKitService.MetricKind,
+        direction: Direction,
+        targetValue: Double?,
+        reviewDate: Date,
+        confirmedAt: Date = .now
+    ) -> WellnessGoal {
+        WellnessGoal(
+            metricKind: metricKind,
+            direction: direction,
+            targetValue: targetValue,
+            targetUnit: metricKind.unit,
+            reviewDate: reviewDate,
+            confirmedAt: confirmedAt
+        )
     }
 }
 
@@ -129,6 +149,8 @@ public struct WellnessPlan: Codable, Identifiable, Sendable, Equatable {
 public enum WellnessPlanTransitionError: Error, Equatable {
     case invalidTransition
     case emptyPlan
+    case unconfirmedGoal
+    case invalidGoal
 }
 
 public enum WellnessPlanLifecycle {
@@ -139,6 +161,16 @@ public enum WellnessPlanLifecycle {
     ) throws -> WellnessPlan {
         if status == .active, plan.goals.isEmpty || plan.actions.isEmpty {
             throw WellnessPlanTransitionError.emptyPlan
+        }
+        if status == .active, plan.goals.contains(where: { $0.confirmedAt == nil }) {
+            throw WellnessPlanTransitionError.unconfirmedGoal
+        }
+        if status == .active, plan.goals.contains(where: { goal in
+            goal.targetUnit != goal.metricKind.unit
+                || goal.targetValue.map { !$0.isFinite || $0 <= 0 } == true
+                || goal.confirmedAt.map { goal.reviewDate < $0 } == true
+        }) {
+            throw WellnessPlanTransitionError.invalidGoal
         }
         let allowed: Set<WellnessPlan.Status>
         switch plan.status {

--- a/S2Y/WellnessPlan/WellnessPlanModels.swift
+++ b/S2Y/WellnessPlan/WellnessPlanModels.swift
@@ -76,6 +76,7 @@ public struct WellnessAction: Codable, Identifiable, Sendable, Equatable {
     public var daysPerWeek: Int
     public var estimatedMinutes: Int
     public var isOptional: Bool
+    public var confirmedAt: Date?
 
     public init(
         id: UUID = UUID(),
@@ -84,7 +85,8 @@ public struct WellnessAction: Codable, Identifiable, Sendable, Equatable {
         category: Category,
         daysPerWeek: Int,
         estimatedMinutes: Int,
-        isOptional: Bool = false
+        isOptional: Bool = false,
+        confirmedAt: Date? = nil
     ) {
         self.id = id
         self.title = title
@@ -93,6 +95,13 @@ public struct WellnessAction: Codable, Identifiable, Sendable, Equatable {
         self.daysPerWeek = min(7, max(1, daysPerWeek))
         self.estimatedMinutes = max(1, estimatedMinutes)
         self.isOptional = isOptional
+        self.confirmedAt = confirmedAt
+    }
+
+    public func confirmed(at date: Date = .now) -> WellnessAction {
+        var copy = self
+        copy.confirmedAt = date
+        return copy
     }
 }
 
@@ -150,6 +159,7 @@ public enum WellnessPlanTransitionError: Error, Equatable {
     case invalidTransition
     case emptyPlan
     case unconfirmedGoal
+    case unconfirmedAction
     case invalidGoal
 }
 
@@ -164,6 +174,9 @@ public enum WellnessPlanLifecycle {
         }
         if status == .active, plan.goals.contains(where: { $0.confirmedAt == nil }) {
             throw WellnessPlanTransitionError.unconfirmedGoal
+        }
+        if status == .active, plan.actions.contains(where: { $0.confirmedAt == nil }) {
+            throw WellnessPlanTransitionError.unconfirmedAction
         }
         if status == .active, plan.goals.contains(where: { goal in
             goal.targetUnit != goal.metricKind.unit

--- a/S2Y/WellnessPlan/WellnessPlanModels.swift
+++ b/S2Y/WellnessPlan/WellnessPlanModels.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct WellnessGoal: Codable, Identifiable, Sendable, Equatable {
-    public enum Direction: String, Codable, Sendable {
+    public enum Direction: String, Codable, Sendable, CaseIterable {
         case increase
         case decrease
         case maintain

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -725,12 +725,12 @@ final class OmerMobileChatModelsTests: XCTestCase {
 
     func testWellnessPlanRequiresExplicitValidActivation() throws {
         let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
-        let goal = WellnessGoal(
+        let goal = WellnessGoal.userSelected(
             metricKind: .sleepDurationHours,
             direction: .consistency,
             targetValue: nil,
-            targetUnit: "hours",
-            reviewDate: date.addingTimeInterval(14 * 86_400)
+            reviewDate: date.addingTimeInterval(14 * 86_400),
+            confirmedAt: date
         )
         let action = WellnessAction(
             title: "Keep a regular wind-down time",
@@ -769,6 +769,33 @@ final class OmerMobileChatModelsTests: XCTestCase {
 
         XCTAssertThrowsError(try WellnessPlanLifecycle.transition(plan, to: .active)) { error in
             XCTAssertEqual(error as? WellnessPlanTransitionError, .emptyPlan)
+        }
+    }
+
+    func testUnconfirmedWellnessGoalCannotActivate() {
+        let goal = WellnessGoal(
+            metricKind: .steps,
+            direction: .consistency,
+            targetValue: nil,
+            targetUnit: "steps",
+            reviewDate: .now.addingTimeInterval(86_400)
+        )
+        let plan = WellnessPlan(
+            title: "Unconfirmed",
+            summary: "Requires an explicit user choice",
+            origin: .assistantDraft,
+            goals: [goal],
+            actions: [WellnessAction(
+                title: "Check in",
+                detail: "Optional reflection",
+                category: .checkIn,
+                daysPerWeek: 1,
+                estimatedMinutes: 1
+            )]
+        )
+
+        XCTAssertThrowsError(try WellnessPlanLifecycle.transition(plan, to: .active)) { error in
+            XCTAssertEqual(error as? WellnessPlanTransitionError, .unconfirmedGoal)
         }
     }
 
@@ -819,12 +846,12 @@ final class OmerMobileChatModelsTests: XCTestCase {
 
     func testOnlyActiveWellnessPlansProduceDailyActions() throws {
         let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
-        let goal = WellnessGoal(
+        let goal = WellnessGoal.userSelected(
             metricKind: .steps,
             direction: .maintain,
             targetValue: 6_000,
-            targetUnit: "steps",
-            reviewDate: date
+            reviewDate: date,
+            confirmedAt: date
         )
         let action = WellnessAction(
             title: "Movement break",
@@ -857,12 +884,12 @@ final class OmerMobileChatModelsTests: XCTestCase {
             daysPerWeek: 7,
             estimatedMinutes: 2
         )
-        let goal = WellnessGoal(
+        let goal = WellnessGoal.userSelected(
             metricKind: .sleepDurationHours,
             direction: .consistency,
             targetValue: nil,
-            targetUnit: "hours",
-            reviewDate: end
+            reviewDate: end,
+            confirmedAt: end
         )
         let draft = WellnessPlan(
             title: "Plan",

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -738,7 +738,7 @@ final class OmerMobileChatModelsTests: XCTestCase {
             category: .sleepRoutine,
             daysPerWeek: 5,
             estimatedMinutes: 20
-        )
+        ).confirmed(at: date)
         let draft = WellnessPlan(
             title: "Sleep consistency",
             summary: "A user-controlled wellness plan.",
@@ -797,6 +797,56 @@ final class OmerMobileChatModelsTests: XCTestCase {
         XCTAssertThrowsError(try WellnessPlanLifecycle.transition(plan, to: .active)) { error in
             XCTAssertEqual(error as? WellnessPlanTransitionError, .unconfirmedGoal)
         }
+    }
+
+    func testUnconfirmedWellnessActionCannotActivate() {
+        let date = Date.now
+        let plan = WellnessPlan(
+            title: "Unconfirmed action",
+            summary: "Requires explicit inclusion",
+            origin: .assistantDraft,
+            goals: [.userSelected(
+                metricKind: .steps,
+                direction: .consistency,
+                targetValue: nil,
+                reviewDate: date.addingTimeInterval(86_400),
+                confirmedAt: date
+            )],
+            actions: [WellnessAction(
+                title: "Movement break",
+                detail: "Optional activity",
+                category: .movement,
+                daysPerWeek: 1,
+                estimatedMinutes: 5
+            )]
+        )
+
+        XCTAssertThrowsError(try WellnessPlanLifecycle.transition(plan, to: .active)) { error in
+            XCTAssertEqual(error as? WellnessPlanTransitionError, .unconfirmedAction)
+        }
+    }
+
+    func testLegacyWellnessItemsDecodeAsUnconfirmed() throws {
+        let goal = WellnessGoal.userSelected(
+            metricKind: .steps,
+            direction: .maintain,
+            targetValue: 5_000,
+            reviewDate: .now.addingTimeInterval(86_400)
+        )
+        let action = WellnessAction(
+            title: "Walk",
+            detail: "Optional movement",
+            category: .movement,
+            daysPerWeek: 2,
+            estimatedMinutes: 5,
+            confirmedAt: .now
+        )
+
+        let legacyGoal = try removingKey("confirmedAt", from: JSONEncoder().encode(goal))
+        let legacyAction = try removingKey("confirmedAt", from: JSONEncoder().encode(action))
+
+        XCTAssertNil(try JSONDecoder().decode(WellnessGoal.self, from: legacyGoal).confirmedAt)
+        XCTAssertNil(try JSONDecoder().decode(WellnessAction.self, from: legacyAction).confirmedAt)
     }
 
     func testWellnessDraftUsesPersonalBaselineWithoutChoosingGoal() throws {
@@ -859,7 +909,7 @@ final class OmerMobileChatModelsTests: XCTestCase {
             category: .movement,
             daysPerWeek: 7,
             estimatedMinutes: 10
-        )
+        ).confirmed(at: date)
         let draft = WellnessPlan(
             title: "Plan",
             summary: "Draft",
@@ -883,7 +933,7 @@ final class OmerMobileChatModelsTests: XCTestCase {
             category: .checkIn,
             daysPerWeek: 7,
             estimatedMinutes: 2
-        )
+        ).confirmed(at: end)
         let goal = WellnessGoal.userSelected(
             metricKind: .sleepDurationHours,
             direction: .consistency,
@@ -1629,6 +1679,12 @@ final class OmerMobileChatModelsTests: XCTestCase {
             healthMetricsDiscussed: [],
             insights: []
         )
+    }
+
+    private func removingKey(_ key: String, from data: Data) throws -> Data {
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: key)
+        return try JSONSerialization.data(withJSONObject: object)
     }
 
     private func validatedWellnessSession() throws -> ValidatedWellnessSession {

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -772,7 +772,7 @@ final class OmerMobileChatModelsTests: XCTestCase {
         }
     }
 
-    func testWellnessDraftUsesPersonalBaselineAndRequiresConfirmation() throws {
+    func testWellnessDraftUsesPersonalBaselineWithoutChoosingGoal() throws {
         let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-12T18:00:00Z"))
         let report = PersonalHealthInsightReport(
             windowDays: 30,
@@ -794,8 +794,10 @@ final class OmerMobileChatModelsTests: XCTestCase {
 
         XCTAssertEqual(draft.plan.status, .draft)
         XCTAssertEqual(draft.plan.origin, .assistantDraft)
-        XCTAssertEqual(draft.plan.goals.first?.targetValue, 6.5)
+        XCTAssertTrue(draft.plan.goals.isEmpty)
+        XCTAssertEqual(draft.plan.actions.first?.category, .sleepRoutine)
         XCTAssertTrue(draft.rationale.first?.contains("your own earlier baseline") == true)
+        XCTAssertTrue(draft.limitations.contains { $0.contains("does not choose a personal target") })
         XCTAssertTrue(draft.limitations.contains { $0.contains("until you confirm") })
     }
 


### PR DESCRIPTION
## Summary
- stop deriving target values and directions from observed health data
- require explicit confirmation and validation for every goal before activation
- let users add or remove their own metric goals in the wellbeing plan UI
- require users to include each suggested action before it can be scheduled
- decode legacy goals and actions as unconfirmed so old drafts cannot silently activate

## Stories
- HLT-091 stop auto-generating wellness goals
- HLT-092 require confirmed wellness goals
- HLT-093 let users choose wellbeing goals
- HLT-094 confirm plan actions before scheduling

## Validation
- iOS Simulator app build passed
- six focused wellbeing-plan tests passed
- full S2YTests unit-test target passed
- local standalone SwiftLint binary was unavailable; CI remains authoritative for lint