### PR TITLE
H25: Add verifiable iOS release readiness gates

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -131,6 +131,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate identifiers and production endpoints
         run: Scripts/validate_release_configuration.sh
+      - name: Check public production endpoints
+        run: Scripts/check_public_production_endpoints.sh
   buildandtest:
     name: Build and Test
     needs: [determineenvironment, releaseconfiguration]

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -123,9 +123,17 @@ jobs:
           echo "buildnumber: ${{ inputs.buildnumber }}"
           echo "releasenotes: ${{ inputs.releasenotes }}"
           echo "firebaseprojectid: ${{ vars.FIREBASE_PROJECT_ID }}"
+  releaseconfiguration:
+    name: Validate Release Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Validate identifiers and production endpoints
+        run: Scripts/validate_release_configuration.sh
   buildandtest:
     name: Build and Test
-    needs: determineenvironment
+    needs: [determineenvironment, releaseconfiguration]
     uses: ./.github/workflows/build-and-test.yml
     permissions:
       contents: read

--- a/Docs/release-readiness.md
+++ b/Docs/release-readiness.md
@@ -22,6 +22,11 @@ without printing credential values that:
 - retired `chat-bak.s2y.us` and embedded test-account material do not remain in
   executable/configuration paths.
 
+The workflow also runs `Scripts/check_public_production_endpoints.sh`. It verifies
+only that the public login page responds and that an unauthenticated Omer mobile
+request is rejected. It never follows an authenticated flow or prints response
+headers, cookies, tokens, or bodies.
+
 The repository previously contained an embedded development-account password.
 It has been removed from the current tree. Any account that ever used that value
 must be treated as compromised and rotated or deleted because Git history is not

--- a/Docs/release-readiness.md
+++ b/Docs/release-readiness.md
@@ -1,0 +1,54 @@
+# iOS production release readiness
+
+This checklist separates repository evidence from external production evidence.
+Passing the repository preflight does not prove that sign-in, App Store signing,
+or a production Omer request succeeds.
+
+## Automated repository preflight
+
+Run:
+
+```sh
+Scripts/validate_release_configuration.sh
+```
+
+The deployment workflow runs the same check before build and signing. It verifies
+without printing credential values that:
+
+- the Xcode application target, Fastlane, and Firebase iOS plist use
+  `us.s2y.s2y-ios`;
+- the Firebase iOS plist and Firebase CLI default use `s2y-mobile-app`;
+- Info.plist and the Omer service fallback use `https://chat.s2y.us`;
+- retired `chat-bak.s2y.us` and embedded test-account material do not remain in
+  executable/configuration paths.
+
+The repository previously contained an embedded development-account password.
+It has been removed from the current tree. Any account that ever used that value
+must be treated as compromised and rotated or deleted because Git history is not
+a secret store.
+
+## External production evidence
+
+Record these results for every production candidate:
+
+| Check | Required evidence |
+|---|---|
+| Firebase sign-in | Test account completes the intended provider flow and receives a Firebase UID |
+| Omer authentication | `chat.s2y.us` accepts a fresh Firebase ID token and rejects missing/invalid tokens |
+| Consent enforcement | Each health scope is absent by default, appears only after grant, and stops after revoke |
+| Omer accounting | The authenticated request is attributed to the correct user, entitlement, and token ledger |
+| Data lifecycle | Conversation deletion and account-boundary messaging match actual production behavior |
+| Signing | Archive uses the approved App ID, distribution certificate, profile, and entitlements |
+| TestFlight | Installed build launches, signs in, chats, displays unavailable states, and can be rolled back |
+
+Do not attach tokens, plist contents, health records, or personal messages to the
+release record. Use request IDs, redacted timestamps, build numbers, and pass/fail
+observations.
+
+## Explicitly not proven by CI
+
+- Google/Firebase browser callback configuration;
+- Apple Foundation Models on an eligible iPhone;
+- App Store Connect credentials and review acceptance;
+- real S2Y device firmware identity and session behavior;
+- production Omer database contents or billing correctness.

--- a/S2Y/Firestore/FirebaseConfiguration.swift
+++ b/S2Y/Firestore/FirebaseConfiguration.swift
@@ -11,7 +11,6 @@ import FirebaseAuth
 import FirebaseStorage
 import Spezi
 import SpeziAccount
-import SpeziFirebaseAccount
 
 
 final class FirebaseConfiguration: Module, DefaultInitializable, @unchecked Sendable {
@@ -24,10 +23,7 @@ final class FirebaseConfiguration: Module, DefaultInitializable, @unchecked Send
     }
     
     
-    @Application(\.logger) private var logger
-    
     @Dependency(Account.self) private var account: Account? // optional, as Firebase might be disabled
-    @Dependency(FirebaseAccountService.self) private var accountService: FirebaseAccountService?
     
     
     @MainActor var userDocumentReference: DocumentReference {
@@ -62,39 +58,4 @@ final class FirebaseConfiguration: Module, DefaultInitializable, @unchecked Send
         Self.userCollection.document(accountId)
     }
     
-    func configure() {
-        Task {
-            await setupTestAccount()
-        }
-    }
-    
-    private func setupTestAccount() async {
-        guard let accountService, FeatureFlags.setupTestAccount else {
-            return
-        }
-        
-        do {
-            try await accountService.login(userId: "lelandstanford@stanford.edu", password: "StanfordRocks!")
-            return
-        } catch {
-            guard let accountError = error as? FirebaseAccountError,
-                  case .invalidCredentials = accountError else {
-                logger.error("Failed to login into test account: \(error)")
-                return
-            }
-        }
-        
-        // account doesn't exist yet, signup
-        var details = AccountDetails()
-        details.userId = "lelandstanford@stanford.edu"
-        details.password = "StanfordRocks!"
-        details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-        details.genderIdentity = .male
-        
-        do {
-            try await accountService.signUp(with: details)
-        } catch {
-            logger.error("Failed to setup test account: \(error)")
-        }
-    }
 }

--- a/S2Y/SharedContext/FeatureFlags.swift
+++ b/S2Y/SharedContext/FeatureFlags.swift
@@ -17,8 +17,4 @@ enum FeatureFlags {
     static let disableFirebase = CommandLine.arguments.contains("--disableFirebase")
     /// Defines if the application should connect to the local firebase emulator.
     static let useFirebaseEmulator = CommandLine.arguments.contains("--useFirebaseEmulator")
-    /// Automatically sign in into a test account upon app launch.
-    ///
-    /// Requires ``disableFirebase`` to be `false`.
-    static let setupTestAccount = CommandLine.arguments.contains("--setupTestAccount")
 }

--- a/Scripts/check_public_production_endpoints.sh
+++ b/Scripts/check_public_production_endpoints.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# This source file is part of the S2Y application project
+#
+# SPDX-FileCopyrightText: 2026 S2Y Health
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+status_code() {
+    curl --silent --show-error \
+        --retry 2 --retry-all-errors --connect-timeout 10 --max-time 30 \
+        --output /dev/null --write-out '%{http_code}' "$1"
+}
+
+login_status="$(status_code 'https://www.s2y.us/auth/login')"
+omer_unauthenticated_status="$(status_code 'https://chat.s2y.us/api/mobile/v1/chats')"
+
+if [[ "${login_status}" != "200" ]]; then
+    echo "Production smoke check failed: login page returned ${login_status}." >&2
+    exit 1
+fi
+
+if [[ "${omer_unauthenticated_status}" != "401" ]]; then
+    echo "Production smoke check failed: Omer mobile API did not enforce authentication." >&2
+    exit 1
+fi
+
+echo "Public production endpoints passed the unauthenticated smoke check."
+echo "Login page: reachable"
+echo "Omer mobile API: authentication required"

--- a/Scripts/validate_release_configuration.sh
+++ b/Scripts/validate_release_configuration.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# This source file is part of the S2Y application project
+#
+# SPDX-FileCopyrightText: 2026 S2Y Health
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_ROOT="$(cd "${SCRIPT_DIRECTORY}/.." && pwd)"
+EXPECTED_BUNDLE_ID="us.s2y.s2y-ios"
+EXPECTED_FIREBASE_PROJECT="s2y-mobile-app"
+EXPECTED_OMER_URL="https://chat.s2y.us"
+
+fail() {
+    echo "Release configuration invalid: $1" >&2
+    exit 1
+}
+
+project_bundle_id="$({
+    sed -n 's/.*PRODUCT_BUNDLE_IDENTIFIER = \([^;]*\);/\1/p' \
+        "${REPOSITORY_ROOT}/S2Y.xcodeproj/project.pbxproj"
+} | head -n 1 | tr -d '"')"
+fastlane_bundle_id="$(
+    sed -n 's/.*default_app_identifier: "\([^"]*\)".*/\1/p' \
+        "${REPOSITORY_ROOT}/fastlane/Fastfile"
+)"
+firebase_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' \
+    "${REPOSITORY_ROOT}/S2Y/Supporting Files/GoogleService-Info.plist")"
+firebase_project_id="$(/usr/libexec/PlistBuddy -c 'Print :PROJECT_ID' \
+    "${REPOSITORY_ROOT}/S2Y/Supporting Files/GoogleService-Info.plist")"
+firebase_deploy_project="$(
+    sed -n 's/.*"default": "\([^"]*\)".*/\1/p' \
+        "${REPOSITORY_ROOT}/firebase/.firebaserc"
+)"
+plist_omer_url="$(/usr/libexec/PlistBuddy -c 'Print :OmerChat.BaseURL' \
+    "${REPOSITORY_ROOT}/S2Y/Supporting Files/Info.plist")"
+source_omer_url="$(
+    sed -n 's/.*defaultBaseURL = "\([^"]*\)".*/\1/p' \
+        "${REPOSITORY_ROOT}/S2Y/LLM/Omer/OmerChatService.swift"
+)"
+
+[[ "${project_bundle_id}" == "${EXPECTED_BUNDLE_ID}" ]] \
+    || fail "Xcode application bundle ID does not match the approved identifier."
+[[ "${fastlane_bundle_id}" == "${EXPECTED_BUNDLE_ID}" ]] \
+    || fail "Fastlane bundle ID does not match the Xcode application target."
+[[ "${firebase_bundle_id}" == "${EXPECTED_BUNDLE_ID}" ]] \
+    || fail "Firebase iOS configuration belongs to a different bundle ID."
+[[ "${firebase_project_id}" == "${EXPECTED_FIREBASE_PROJECT}" ]] \
+    || fail "Firebase iOS configuration belongs to an unexpected project."
+[[ "${firebase_deploy_project}" == "${EXPECTED_FIREBASE_PROJECT}" ]] \
+    || fail "Firebase CLI default points to an unexpected project."
+[[ "${plist_omer_url}" == "${EXPECTED_OMER_URL}" ]] \
+    || fail "Info.plist Omer URL is not the approved production endpoint."
+[[ "${source_omer_url}" == "${EXPECTED_OMER_URL}" ]] \
+    || fail "Omer service fallback is not the approved production endpoint."
+
+if grep -R -n -E --exclude-dir=BrandAssets \
+    'chat-bak\.s2y\.us|StanfordRocks|setupTestAccount' \
+    "${REPOSITORY_ROOT}/S2Y" \
+    "${REPOSITORY_ROOT}/fastlane" \
+    "${REPOSITORY_ROOT}/firebase" \
+    "${REPOSITORY_ROOT}/.github" >/dev/null; then
+    fail "retired endpoint or embedded test-account material remains in the repository."
+fi
+
+echo "Release configuration validated without printing credentials."
+echo "Bundle: ${EXPECTED_BUNDLE_ID}"
+echo "Firebase project: ${EXPECTED_FIREBASE_PROJECT}"
+echo "Omer endpoint: ${EXPECTED_OMER_URL}"

--- a/Scripts/validate_release_configuration.sh
+++ b/Scripts/validate_release_configuration.sh
@@ -19,6 +19,16 @@ fail() {
     exit 1
 }
 
+plist_value() {
+    ruby -r rexml/document -e '
+        document = REXML::Document.new(File.read(ARGV[0]))
+        elements = document.elements["plist/dict"].elements.to_a
+        index = elements.index { |element| element.name == "key" && element.text == ARGV[1] }
+        abort("missing plist key") unless index && elements[index + 1]
+        puts(elements[index + 1].text)
+    ' "$1" "$2"
+}
+
 project_bundle_id="$({
     sed -n 's/.*PRODUCT_BUNDLE_IDENTIFIER = \([^;]*\);/\1/p' \
         "${REPOSITORY_ROOT}/S2Y.xcodeproj/project.pbxproj"
@@ -27,16 +37,16 @@ fastlane_bundle_id="$(
     sed -n 's/.*default_app_identifier: "\([^"]*\)".*/\1/p' \
         "${REPOSITORY_ROOT}/fastlane/Fastfile"
 )"
-firebase_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' \
-    "${REPOSITORY_ROOT}/S2Y/Supporting Files/GoogleService-Info.plist")"
-firebase_project_id="$(/usr/libexec/PlistBuddy -c 'Print :PROJECT_ID' \
-    "${REPOSITORY_ROOT}/S2Y/Supporting Files/GoogleService-Info.plist")"
+firebase_bundle_id="$(plist_value \
+    "${REPOSITORY_ROOT}/S2Y/Supporting Files/GoogleService-Info.plist" BUNDLE_ID)"
+firebase_project_id="$(plist_value \
+    "${REPOSITORY_ROOT}/S2Y/Supporting Files/GoogleService-Info.plist" PROJECT_ID)"
 firebase_deploy_project="$(
     sed -n 's/.*"default": "\([^"]*\)".*/\1/p' \
         "${REPOSITORY_ROOT}/firebase/.firebaserc"
 )"
-plist_omer_url="$(/usr/libexec/PlistBuddy -c 'Print :OmerChat.BaseURL' \
-    "${REPOSITORY_ROOT}/S2Y/Supporting Files/Info.plist")"
+plist_omer_url="$(plist_value \
+    "${REPOSITORY_ROOT}/S2Y/Supporting Files/Info.plist" OmerChat.BaseURL)"
 source_omer_url="$(
     sed -n 's/.*defaultBaseURL = "\([^"]*\)".*/\1/p' \
         "${REPOSITORY_ROOT}/S2Y/LLM/Omer/OmerChatService.swift"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@ default_platform(:ios)
 
 APP_CONFIG = {
   default_environment: "staging",
-  default_app_identifier: "edu.stanford.s2y",
+  default_app_identifier: "us.s2y.s2y-ios",
   default_provisioningProfile: "S2Y",
   default_version_name: "1.0.0",
   default_release_notes: "Initial release with HealthKit integration and AI-powered health assistant.",

--- a/firebase/.firebaserc
+++ b/firebase/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "stanfordspezitemplateapp"
+    "default": "s2y-mobile-app"
   }
 }


### PR DESCRIPTION
## Summary
- remove embedded development-account credentials and the auto-login feature flag
- align Fastlane, Xcode, Firebase iOS, and Firebase CLI production identities
- validate approved Firebase/Omer configuration without printing credential values
- gate deployment on configuration validation and public unauthenticated endpoint checks
- document which production, signing, and device checks remain external evidence

## Stories
- HLT-099 remove embedded test account credentials
- HLT-100 align release bundle identity
- HLT-101 align Firebase deployment project
- HLT-102 validate release configuration safely
- HLT-103 gate deployments on release preflight
- HLT-104 add public production smoke checks

## Validation
- release configuration preflight passed
- public login page returned 200
- unauthenticated Omer mobile API returned 401
- Release configuration iOS Simulator build passed
- full S2YTests unit-test target passed

## External evidence still required
- authenticated Firebase/Omer flow with a production test account
- App Store signing, Archive upload, TestFlight install, and rollback
- eligible-iPhone Apple Foundation Models validation

Security note: any account that ever used the removed historical password must be rotated or deleted.