### PR TITLE
H51: repair privacy URL construction

### DIFF
--- a/S2Y/Profile/AboutView.swift
+++ b/S2Y/Profile/AboutView.swift
@@ -13,7 +13,7 @@ enum S2YPublicLinks {
     static let sourceCode = "https://github.com/javenisme/s2y-app-iOS"
     static let reportIssue = "https://github.com/javenisme/s2y-app-iOS/issues/new"
     static let privacyPolicy = "https://www.s2y.us/privacy-policy"
-    static let privacyPolicyURL: URL = "https://www.s2y.us/privacy-policy"
+    static let privacyPolicyURL = URL(string: privacyPolicy) ?? URL(fileURLWithPath: "/")
     static let termsOfService = "https://www.s2y.us/terms-service"
     static let consumerHealthDataPrivacy = "https://www.s2y.us/consumer-health-data-privacy"
     static let openSourceLicense = "https://opensource.org/license/mit/"


### PR DESCRIPTION
## Story
- HLT-166: repair privacy URL construction

## Cause
The H49 URL constant passed SwiftLint but used a String-to-URL conversion unsupported by the active Swift toolchain while self-hosted build checks remained queued.

## Validation
- Locally signed simulator build succeeded
- PublicProductSurfaceTests passed
- No force unwrap and no change to the published privacy destination