### PR TITLE
Show unified S2Y membership in iOS

### DIFF
--- a/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
+++ b/S2Y/HealthAssistant/HealthAssistantSettingsView.swift
@@ -17,6 +17,9 @@ struct HealthAssistantSettingsView: View {
     @State private var omerAuthorization: HealthSharingAuthorization?
     @State private var isCheckingOmerAuthorization = false
     @State private var consentSyncRequestID = UUID()
+    @State private var membership: OmerMembershipStatus?
+    @State private var membershipMessage: String?
+    @State private var isLoadingMembership = false
 
     private var appleModelAvailability: AppleFoundationModelAvailability {
         AppleFoundationModelService.shared.availability
@@ -44,6 +47,8 @@ struct HealthAssistantSettingsView: View {
                 )
             }
 
+            membershipSection
+
             privacySection
 
             planSection
@@ -63,6 +68,62 @@ struct HealthAssistantSettingsView: View {
         }
         .task {
             startConsentSynchronization()
+            await loadMembership()
+        }
+    }
+
+    @ViewBuilder private var membershipSection: some View {
+        Section {
+            if let membership {
+                LabeledContent("Membership", value: membership.plan.capitalized)
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Omer AI this month")
+                        Spacer()
+                        Text("\(membership.ai.remainingTokens.formatted()) tokens left")
+                            .foregroundStyle(.secondary)
+                    }
+                    ProgressView(
+                        value: Double(membership.ai.usedTokens),
+                        total: Double(max(membership.ai.monthlyTokenLimit, 1))
+                    )
+                }
+                .accessibilityElement(children: .combine)
+
+                LabeledContent(
+                    "Reward credit",
+                    value: (Double(membership.rewards.points) / 100).formatted(.currency(code: "USD"))
+                )
+
+                ShareLink(item: membership.rewards.shareUrl) {
+                    Label("Invite someone to S2Y", systemImage: "square.and.arrow.up")
+                }
+
+                Link(destination: membership.manageUrl) {
+                    Label("Manage Membership", systemImage: "creditcard")
+                }
+            } else if isLoadingMembership {
+                HStack {
+                    ProgressView()
+                    Text("Loading membership…")
+                }
+            } else {
+                Button("Refresh Membership", systemImage: "arrow.clockwise") {
+                    Task { await loadMembership() }
+                }
+            }
+        } header: {
+            Text("S2Y Account")
+        } footer: {
+            if let membershipMessage {
+                Text(membershipMessage)
+                    .foregroundStyle(.orange)
+            } else {
+                Text(
+                    "Your Omer AI allowance, membership, and referral rewards use the same S2Y account. "
+                        + "Available reward credit is applied when you start checkout."
+                )
+            }
         }
     }
 
@@ -237,6 +298,18 @@ struct HealthAssistantSettingsView: View {
                 consentSyncMessage = "This choice is applied on this iPhone. Cloud confirmation is pending until Omer is reachable."
             }
         }
+    }
+
+    private func loadMembership() async {
+        isLoadingMembership = true
+        membershipMessage = nil
+        do {
+            membership = try await OmerChatService.shared.fetchMembership()
+        } catch {
+            membership = nil
+            membershipMessage = "Sign in and connect to Omer to load your S2Y membership."
+        }
+        isLoadingMembership = false
     }
 }
 

--- a/S2Y/LLM/Omer/OmerChatModels.swift
+++ b/S2Y/LLM/Omer/OmerChatModels.swift
@@ -51,6 +51,29 @@ struct OmerBillingStatus: Decodable, Equatable, Sendable {
     let remainingTokens: Int
 }
 
+struct OmerMembershipStatus: Decodable, Equatable, Sendable {
+    struct AIUsage: Decodable, Equatable, Sendable {
+        let usedTokens: Int
+        let monthlyTokenLimit: Int
+        let remainingTokens: Int
+    }
+
+    struct Rewards: Decodable, Equatable, Sendable {
+        let points: Int
+        let qualifiedReferrals: Int
+        let referralCode: String
+        let shareUrl: URL
+    }
+
+    let plan: String
+    let subscriptionStatus: String
+    let billingInterval: String?
+    let currentPeriodEnd: String?
+    let ai: AIUsage
+    let rewards: Rewards
+    let manageUrl: URL
+}
+
 struct OmerLocalChatSyncRequest: Encodable {
     struct Message: Encodable {
         let id: UUID

--- a/S2Y/LLM/Omer/OmerChatService.swift
+++ b/S2Y/LLM/Omer/OmerChatService.swift
@@ -204,6 +204,14 @@ actor OmerChatService {
         return detail
     }
 
+    func fetchMembership() async throws -> OmerMembershipStatus {
+        let serviceURL = try configuredServiceURL()
+        let data = try await authenticatedGET(
+            url: serviceURL.appendingPathComponent("api/mobile/membership")
+        )
+        return try decoder.decode(OmerMembershipStatus.self, from: data)
+    }
+
     func deleteChat(id: UUID) async throws {
         let serviceURL = try configuredServiceURL()
         let url = serviceURL

--- a/S2YTests/OmerMobileChatModelsTests.swift
+++ b/S2YTests/OmerMobileChatModelsTests.swift
@@ -9,6 +9,38 @@
 import XCTest
 
 final class OmerMobileChatModelsTests: XCTestCase {
+    func testMembershipDecodesUnifiedCommercialState() throws {
+        let data = Data(
+            """
+            {
+              "plan": "pro",
+              "subscriptionStatus": "active",
+              "billingInterval": "monthly",
+              "currentPeriodEnd": "2026-09-14T00:00:00.000Z",
+              "ai": {
+                "usedTokens": 2500,
+                "monthlyTokenLimit": 2000000,
+                "remainingTokens": 1997500
+              },
+              "rewards": {
+                "points": 500,
+                "qualifiedReferrals": 1,
+                "referralCode": "S2YCODE",
+                "shareUrl": "https://s2yhealth.com/?ref=S2YCODE"
+              },
+              "manageUrl": "https://chat.s2y.us/pricing"
+            }
+            """.utf8
+        )
+
+        let status = try JSONDecoder().decode(OmerMembershipStatus.self, from: data)
+
+        XCTAssertEqual(status.plan, "pro")
+        XCTAssertEqual(status.ai.remainingTokens, 1_997_500)
+        XCTAssertEqual(status.rewards.points, 500)
+        XCTAssertEqual(status.rewards.referralCode, "S2YCODE")
+    }
+
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
 


### PR DESCRIPTION
## Summary
- fetch the shared S2Y membership state from Omer
- show plan, Omer AI usage, reward credit, referral sharing, and membership management in iOS
- add membership response decoding coverage

## Validation
- selected membership model test passed
- iOS app and test target compiled successfully